### PR TITLE
예약 엔티티 및 레포지토리 생성

### DIFF
--- a/src/main/java/com/zero/bwtableback/reservation/entity/Reservation.java
+++ b/src/main/java/com/zero/bwtableback/reservation/entity/Reservation.java
@@ -1,0 +1,58 @@
+package com.zero.bwtableback.reservation.entity;
+
+import com.zero.bwtableback.common.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Reservation extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+//    @ManyToOne
+//    @JoinColumn(updatable = false, nullable = false)
+//    private Restaurant restaurant;
+//
+//    @ManyToOne
+//    @JoinColumn(updatable = false, nullable = false)
+//    private User user;
+
+    @Column(nullable = false)
+    private LocalDate reservationDate;
+
+    @Column(nullable = false)
+    private LocalTime reservationTime;
+
+    @Column(nullable = false)
+    private int numberOfPeople;
+
+    private String specialRequests;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReservationStatus reservationStatus;
+
+//    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL)
+//    private List<Payment> payments;
+//
+//    @OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL)
+//    private List<Notification> notifications;
+
+}

--- a/src/main/java/com/zero/bwtableback/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/zero/bwtableback/reservation/entity/ReservationStatus.java
@@ -1,9 +1,9 @@
 package com.zero.bwtableback.reservation.entity;
 
 public enum ReservationStatus {
-    WAITING, // 예약 대기
     CONFIRMED, // 예약 확정
-    CANCELED,  // 예약 취소
+    CUSTOMER_CANCELED, // 예약 취소
+    OWNER_CANCELED, // 예약 취소
+    NO_SHOW, // 노쇼
     VISITED // 방문 완료
-
 }

--- a/src/main/java/com/zero/bwtableback/reservation/entity/ReservationStatus.java
+++ b/src/main/java/com/zero/bwtableback/reservation/entity/ReservationStatus.java
@@ -1,0 +1,9 @@
+package com.zero.bwtableback.reservation.entity;
+
+public enum ReservationStatus {
+    WAITING, // 예약 대기
+    CONFIRMED, // 예약 확정
+    CANCELED,  // 예약 취소
+    VISITED // 방문 완료
+
+}

--- a/src/main/java/com/zero/bwtableback/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/zero/bwtableback/reservation/repository/ReservationRepository.java
@@ -9,10 +9,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-    //    Page<Reservation> findByRestaurantName(String restaurantName, Pageable pageable);
+    // 가게명으로 예약 목록을 조회
+    // Page<Reservation> findByRestaurantName(String restaurantName, Pageable pageable);
 
+    // 예약일자, 예약시간으로 예약 목록 조회
     Page<Reservation> findByReservationDateAndReservationTime(LocalDate date, LocalTime time, Pageable pageable);
 
-    //    Page<Reservation> findByRestaurantNameAndDate(String restaurantName, LocalDate date, Pageable pageable);
+    // 가게명, 예약일자로 예약 목록 조회
+    // Page<Reservation> findByRestaurantNameAndDate(String restaurantName, LocalDate date, Pageable pageable);
 
 }

--- a/src/main/java/com/zero/bwtableback/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/zero/bwtableback/reservation/repository/ReservationRepository.java
@@ -1,0 +1,18 @@
+package com.zero.bwtableback.reservation.repository;
+
+import com.zero.bwtableback.reservation.entity.Reservation;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    //    Page<Reservation> findByRestaurantName(String restaurantName, Pageable pageable);
+
+    Page<Reservation> findByReservationDateAndReservationTime(LocalDate date, LocalTime time, Pageable pageable);
+
+    //    Page<Reservation> findByRestaurantNameAndDate(String restaurantName, LocalDate date, Pageable pageable);
+
+}

--- a/src/test/java/com/zero/bwtableback/reservation/ReservationRepositoryTest.java
+++ b/src/test/java/com/zero/bwtableback/reservation/ReservationRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.zero.bwtableback.reservation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zero.bwtableback.reservation.entity.Reservation;
+import com.zero.bwtableback.reservation.entity.ReservationStatus;
+import com.zero.bwtableback.reservation.repository.ReservationRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@DataJpaTest
+public class ReservationRepositoryTest {
+
+    @Autowired
+    ReservationRepository reservationRepository;
+
+    private LocalDate testDate;
+    private LocalTime testTime;
+
+    @BeforeEach
+    public void setup() {
+
+        // 테스트용 날짜와 시간 설정
+        testDate = LocalDate.of(2024, 11, 1);
+        testTime = LocalTime.of(18, 0);
+
+        // 테스트 데이터 삽입
+        Reservation reservation1 = Reservation.builder()
+                .reservationDate(testDate)
+                .reservationTime(testTime)
+                .numberOfPeople(4)
+                .specialRequests("Vegetarian")
+                .reservationStatus(ReservationStatus.CONFIRMED)
+                .build();
+        reservationRepository.save(reservation1);
+
+        Reservation reservation2 = Reservation.builder()
+                .reservationDate(testDate)
+                .reservationTime(LocalTime.of(19, 0))
+                .numberOfPeople(2)
+                .specialRequests("Less salty")
+                .reservationStatus(ReservationStatus.CONFIRMED)
+                .build();
+        reservationRepository.save(reservation2);
+
+        Reservation reservation3 = Reservation.builder()
+                .reservationDate(LocalDate.of(2024, 11, 2))
+                .reservationTime(testTime)
+                .numberOfPeople(3)
+                .specialRequests("Near entrance")
+                .reservationStatus(ReservationStatus.WAITING)
+                .build();
+        reservationRepository.save(reservation3);
+
+    }
+
+    @DisplayName("특정 날짜와 시간으로 예약을 검색하면 정보가 정확히 반환된다")
+    @Test
+    public void givenReservationExistsForDateAndTime_whenFindingByDateAndTime_thenReturnMatchingReservation() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10);
+
+        // when
+        Page<Reservation> result = reservationRepository.findByReservationDateAndReservationTime(testDate, testTime, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1); // 조회된 예약 건수가 1건인지 확인
+        Reservation reservation = result.getContent().get(0); // 내용 일치 확인
+        assertThat(reservation.getReservationDate()).isEqualTo(testDate);
+        assertThat(reservation.getReservationTime()).isEqualTo(testTime);
+        assertThat(reservation.getNumberOfPeople()).isEqualTo(4);
+        assertThat(reservation.getSpecialRequests()).isEqualTo("Vegetarian");
+        assertThat(reservation.getReservationStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+    }
+}


### PR DESCRIPTION
### 변경 사항
- [X] 신규 기능 추가 

### 작업 내역

예약 엔티티 생성
-  Reservation 엔티티 생성
-  common 패키지의 BaseEntity 상속
-  기본 필드 추가
-  Restaurant와 일대다 관계 설정
-  User와 일대다 관계 설정
-  Payment와 다대일 관계 설정
-  Notification과 다대일 관계 설정

예약 상태
-  ReservationStatus ENUM 클래스 생성

예약 레포지토리
-  ReservationRepository 인터페이스 생성
-  JpaRepository 상속

레포지토리 테스트 코드
-  특정 날짜와 시간으로 예약을 검색하면 정보가 정확히 반환되는지 검증

### 테스트
- [X] 테스트 추가
- [X] 모든 테스트가 통과

## 다음 진행사항
- 예약과 연관 관계가 있는 알림 및 결제 도메인 구현
- 예약 dto 및 서비스 구현
- 회원 계정 엔티티 이름 Member와 User 중 어떤 것 사용하는지 확인 후 반영 (현재는 ERD 기반으로 User로 작성한 상태)

## 참고
closes #9 
