### PR TITLE
예약 알림 스케쥴링 및 전송 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-devtools'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-batch'
 
 	implementation 'org.springframework.data:spring-data-envers'
 
@@ -51,6 +52,7 @@ dependencies {
 
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.batch:spring-batch-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/zero/bwtableback/BwTableBackApplication.java
+++ b/src/main/java/com/zero/bwtableback/BwTableBackApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 @EnableSpringDataWebSupport(pageSerializationMode = EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO)
 public class BwTableBackApplication {

--- a/src/main/java/com/zero/bwtableback/common/exception/ErrorCode.java
+++ b/src/main/java/com/zero/bwtableback/common/exception/ErrorCode.java
@@ -30,11 +30,6 @@ public enum ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 토큰입니다."),
 
-    // 예약 생성 관련 오류
-    INVALID_PEOPLE_COUNT(HttpStatus.BAD_REQUEST, "인원 설정은 최소 한 명입니다."),
-    INVALID_RESERVATION_DATE(HttpStatus.BAD_REQUEST, "현재보다 과거의 날짜는 예약이 불가합니다."),
-    INVALID_RESERVATION_TIME(HttpStatus.BAD_REQUEST, "현재보다 과거의 시간은 예약이 불가합니다."),
-
     // 예약 내역 조회 관련 오류
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예약을 찾을 수 없습니다."),
     RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 가게를 찾을 수 없습니다."),
@@ -42,6 +37,7 @@ public enum ErrorCode {
     RESERVATION_FULL(HttpStatus.CONFLICT, "해당 시간대 예약이 마감되었습니다."),
 
     // 예약 상태 변경 관련 오류
+    INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 예약 상태입니다."),
     INVALID_STATUS_CONFIRM(HttpStatus.CONFLICT, "이미 확정되었거나, 취소, 노쇼, 방문 완료된 예약은 다시 확정할 수 없습니다."),
     INVALID_STATUS_CUSTOMER_CANCEL(HttpStatus.CONFLICT, "고객 취소는 확정된 예약에 대해서만 가능합니다."),
     INVALID_STATUS_OWNER_CANCEL(HttpStatus.CONFLICT, "가게 취소는 확정된 예약에 대해서만 가능합니다."),
@@ -57,6 +53,8 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "알림을 찾을 수 없습니다."),
     NOTIFICATION_ALREADY_SENT(HttpStatus.BAD_REQUEST, "이미 전송된 알림입니다."),
     NOTIFICATION_SCHEDULED_TIME_NOT_REACHED(HttpStatus.BAD_REQUEST, "예정된 전송 시간이 아닙니다."),
+    NOTIFICATION_SEND_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "알림 전송에 실패했습니다."),
+    JSON_PARSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "알림 데이터 JSON 파싱 작업이 실패했습니다."),
 
     // 기타 오류
     UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/zero/bwtableback/reservation/batch/DayOfVisitNotificationJobConfig.java
+++ b/src/main/java/com/zero/bwtableback/reservation/batch/DayOfVisitNotificationJobConfig.java
@@ -1,0 +1,81 @@
+package com.zero.bwtableback.reservation.batch;
+
+import com.zero.bwtableback.reservation.entity.Notification;
+import com.zero.bwtableback.reservation.entity.NotificationType;
+import com.zero.bwtableback.reservation.entity.Reservation;
+import com.zero.bwtableback.reservation.repository.ReservationRepository;
+import com.zero.bwtableback.reservation.service.NotificationScheduleService;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class DayOfVisitNotificationJobConfig {
+
+    private final JobRepository jobRepository;
+    private final NotificationScheduleService notificationScheduleService;
+    private final PlatformTransactionManager platformTransactionManager;
+
+    @Bean
+    public Job sendDayOfVisitNotificationJob(Step sendDayOfVisitNotificationStep) {
+        return new JobBuilder("sendDayOfVisitNotificationJob", jobRepository)
+                .start(sendDayOfVisitNotificationStep)
+                .build();
+    }
+
+    @Bean
+    public Step sendDayOfVisitNotificationStep(ReservationRepository reservationRepository) {
+        return new StepBuilder("sendDayOfVisitNotificationStep", jobRepository)
+                .<Reservation, Notification>chunk(50, platformTransactionManager)
+                .reader(todayReservationsReader(reservationRepository))
+                .processor(dayOfVisitNotificationProcessor())
+                .writer(dayOfVisitNotificationWriter())
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public ItemReader<Reservation> todayReservationsReader(ReservationRepository reservationRepository) {
+        LocalDate today = LocalDate.now();
+        List<Reservation> reservations = reservationRepository.findReservationsByDate(today);
+        return new ListItemReader<>(reservations);
+    }
+    // 예약 알림 생성 Processor
+    @Bean
+    public ItemProcessor<Reservation, Notification> dayOfVisitNotificationProcessor() {
+        return reservation -> {
+            Notification notification = notificationScheduleService.createAndSaveNotification(
+                    reservation, NotificationType.DAY_OF_VISIT);
+            log.info("예약 알림 생성 완료: {}", reservation.getId());
+            return notification;
+        };
+    }
+
+    // 예약 알림 전송 Writer
+    @Bean
+    public ItemWriter<Notification> dayOfVisitNotificationWriter() {
+        return notifications -> notifications.forEach(notification -> {
+            notificationScheduleService.sendNotification(notification);
+            log.info("예약 알림 전송 완료: {}", notification.getId());
+        });
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/reservation/batch/DeleteNotificationsJobConfig.java
+++ b/src/main/java/com/zero/bwtableback/reservation/batch/DeleteNotificationsJobConfig.java
@@ -1,0 +1,72 @@
+package com.zero.bwtableback.reservation.batch;
+
+import com.zero.bwtableback.reservation.entity.NotificationStatus;
+import com.zero.bwtableback.reservation.repository.NotificationRepository;
+import java.time.LocalDateTime;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.data.RepositoryItemReader;
+import org.springframework.batch.item.data.builder.RepositoryItemReaderBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.Sort;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Slf4j
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class DeleteNotificationsJobConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager platformTransactionManager;
+
+    @Bean
+    public Job deleteOldNotificationsJob(Step deleteOldNotificationsStep) {
+        return new JobBuilder("deleteOldNotificationsJob", jobRepository)
+                .start(deleteOldNotificationsStep)
+                .build();
+    }
+
+    @Bean
+    public Step deleteOldNotificationsStep(NotificationRepository notificationRepository) {
+        return new StepBuilder("deleteOldNotificationsStep", jobRepository)
+                .<Long, Long>chunk(50, platformTransactionManager)
+                .reader(oldNotificationIdsReader(notificationRepository))
+                .writer(oldNotificationsWriter(notificationRepository))
+                .build();
+    }
+
+    @Bean
+    @StepScope
+    public RepositoryItemReader<Long> oldNotificationIdsReader(NotificationRepository notificationRepository) {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusWeeks(1);
+
+        return new RepositoryItemReaderBuilder<Long>()
+                .name("oldNotificationIdsReader")
+                .repository(notificationRepository)
+                .methodName("findIdsBySentTimeBeforeAndStatus")
+                .arguments(cutoffDate, NotificationStatus.SENT)
+                .pageSize(50)
+                .sorts(Map.of("id", Sort.Direction.ASC))
+                .build();
+    }
+
+    @Bean
+    public ItemWriter<Long> oldNotificationsWriter(NotificationRepository notificationRepository) {
+        return ids -> {
+            notificationRepository.deleteAllByIdInBatch((Iterable<Long>) ids);
+            log.info("일주일 지난 알림 {}건 삭제 완료", ids.size());
+        };
+    }
+    
+}

--- a/src/main/java/com/zero/bwtableback/reservation/controller/NotificationController.java
+++ b/src/main/java/com/zero/bwtableback/reservation/controller/NotificationController.java
@@ -1,21 +1,27 @@
 package com.zero.bwtableback.reservation.controller;
 
-//import com.zero.bwtableback.reservation.dto.NotificationResDto;
+import com.zero.bwtableback.reservation.dto.NotificationResDto;
 import com.zero.bwtableback.reservation.entity.Notification;
 import com.zero.bwtableback.reservation.entity.NotificationType;
 import com.zero.bwtableback.reservation.entity.Reservation;
+import com.zero.bwtableback.reservation.service.NotificationEmitterService;
 import com.zero.bwtableback.reservation.service.NotificationSearchService;
 import com.zero.bwtableback.reservation.service.ReservationService;
+import com.zero.bwtableback.security.MemberDetails;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Slf4j
 @RestController
@@ -24,22 +30,28 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final ReservationService reservationService;
+    private final NotificationEmitterService notificationEmitterService;
     private final NotificationSearchService notificationSearchService;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(@AuthenticationPrincipal MemberDetails memberDetails,
+                                @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "")
+                                String lastEventId) {
+        return notificationEmitterService.subscribe(memberDetails.getMemberId(), lastEventId);
+    }
 
     // 고객 회원에게 전송된 알림 목록 조회
     @GetMapping("/customers/{userId}")
     public Page<?> getCustomerNotifications(@PathVariable Long userId, Pageable pageable) {
         Page<Notification> notifications = notificationSearchService.getNotificationsSentToCustomer(userId, pageable);
-//        return notifications.map(NotificationResDto::fromEntity);
-        return null;
+        return notifications.map(NotificationResDto::fromEntity);
     }
 
     // 가게 주인 회원에게 전송된 알림 목록 조회
     @GetMapping("/owners/{ownerId}")
     public Page<?> getOwnerNotifications(@PathVariable Long ownerId, Pageable pageable) {
         Page<Notification> notifications = notificationSearchService.getNotificationsSentToOwner(ownerId, pageable);
-//        return notifications.map(NotificationResDto::fromEntity);
-        return null;
+        return notifications.map(NotificationResDto::fromEntity);
     }
 
     // 메시지 생성에 사용할 수 있는 알림 정보 반환

--- a/src/main/java/com/zero/bwtableback/reservation/controller/NotificationController.java
+++ b/src/main/java/com/zero/bwtableback/reservation/controller/NotificationController.java
@@ -42,14 +42,14 @@ public class NotificationController {
 
     // 고객 회원에게 전송된 알림 목록 조회
     @GetMapping("/customers/{userId}")
-    public Page<?> getCustomerNotifications(@PathVariable Long userId, Pageable pageable) {
+    public Page<NotificationResDto> getCustomerNotifications(@PathVariable Long userId, Pageable pageable) {
         Page<Notification> notifications = notificationSearchService.getNotificationsSentToCustomer(userId, pageable);
         return notifications.map(NotificationResDto::fromEntity);
     }
 
     // 가게 주인 회원에게 전송된 알림 목록 조회
     @GetMapping("/owners/{ownerId}")
-    public Page<?> getOwnerNotifications(@PathVariable Long ownerId, Pageable pageable) {
+    public Page<NotificationResDto> getOwnerNotifications(@PathVariable Long ownerId, Pageable pageable) {
         Page<Notification> notifications = notificationSearchService.getNotificationsSentToOwner(ownerId, pageable);
         return notifications.map(NotificationResDto::fromEntity);
     }

--- a/src/main/java/com/zero/bwtableback/reservation/dto/NotificationResDto.java
+++ b/src/main/java/com/zero/bwtableback/reservation/dto/NotificationResDto.java
@@ -1,0 +1,22 @@
+package com.zero.bwtableback.reservation.dto;
+
+import com.zero.bwtableback.reservation.entity.Notification;
+import com.zero.bwtableback.reservation.entity.NotificationType;
+import com.zero.bwtableback.reservation.entity.NotificationStatus;
+import java.time.LocalDateTime;
+
+public record NotificationResDto(
+        Long id,
+        Long reservationId,
+        NotificationType notificationType,
+        String message
+) {
+    public static NotificationResDto fromEntity(Notification notification) {
+        return new NotificationResDto(
+                notification.getId(),
+                notification.getReservation().getId(),
+                notification.getNotificationType(),
+                notification.getMessage()
+        );
+    }
+}

--- a/src/main/java/com/zero/bwtableback/reservation/repository/EmitterRepository.java
+++ b/src/main/java/com/zero/bwtableback/reservation/repository/EmitterRepository.java
@@ -1,0 +1,49 @@
+package com.zero.bwtableback.reservation.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Repository
+public class EmitterRepository {
+
+    // key: memberId_emitterId (복합키) - value: SseEmitter
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    // 새로운 연결 저장
+    public void saveEmitter(String emitterId, SseEmitter emitter, Long memberId) {
+        String compositeKey = generateCompositeKey(memberId, emitterId);
+        emitters.put(compositeKey, emitter);
+    }
+
+    // 특정 사용자의 활성화된 emitterId 리스트 조회
+    public List<String> findAllEmitterIdsByMemberId(Long memberId) {
+        List<String> emitterIds = new ArrayList<>();
+        emitters.keySet().forEach(key -> {
+            if (key.startsWith(memberId + "_")) {
+                emitterIds.add(key);
+            }
+        });
+        return emitterIds;
+    }
+
+    // emitter id로 emitter 객체 조회
+    public SseEmitter findById(String emitterId) {
+        return emitters.get(emitterId);
+    }
+
+    // 특정 emitter 제거
+    public void removeEmitter(String emitterId) {
+        emitters.remove(emitterId);
+    }
+
+    // memberId와 emitterId를 조합하여 복합 키 생성
+    private String generateCompositeKey(Long memberId, String emitterId) {
+        return memberId + "_" + emitterId;
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/reservation/repository/EmitterRepository.java
+++ b/src/main/java/com/zero/bwtableback/reservation/repository/EmitterRepository.java
@@ -1,26 +1,24 @@
 package com.zero.bwtableback.reservation.repository;
 
-import org.springframework.stereotype.Repository;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Repository
 public class EmitterRepository {
 
-    // key: memberId_emitterId (복합키) - value: SseEmitter
+    // 활성화된 emitter를 관리하는 map
     private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
 
-    // 새로운 연결 저장
-    public void saveEmitter(String emitterId, SseEmitter emitter, Long memberId) {
-        String compositeKey = generateCompositeKey(memberId, emitterId);
-        emitters.put(compositeKey, emitter);
+    // 고유한 emitterId를 키로 사용하여 저장
+    public void saveEmitter(String emitterId, SseEmitter emitter) {
+        emitters.put(emitterId, emitter);
     }
 
-    // 특정 사용자의 활성화된 emitterId 리스트 조회
+    // 특정 사용자의 emitterId 리스트 조회
     public List<String> findAllEmitterIdsByMemberId(Long memberId) {
         List<String> emitterIds = new ArrayList<>();
         emitters.keySet().forEach(key -> {
@@ -31,19 +29,12 @@ public class EmitterRepository {
         return emitterIds;
     }
 
-    // emitter id로 emitter 객체 조회
     public SseEmitter findById(String emitterId) {
         return emitters.get(emitterId);
     }
 
-    // 특정 emitter 제거
     public void removeEmitter(String emitterId) {
         emitters.remove(emitterId);
-    }
-
-    // memberId와 emitterId를 조합하여 복합 키 생성
-    private String generateCompositeKey(Long memberId, String emitterId) {
-        return memberId + "_" + emitterId;
     }
 
 }

--- a/src/main/java/com/zero/bwtableback/reservation/repository/NotificationRepository.java
+++ b/src/main/java/com/zero/bwtableback/reservation/repository/NotificationRepository.java
@@ -2,13 +2,13 @@ package com.zero.bwtableback.reservation.repository;
 
 import com.zero.bwtableback.reservation.entity.Notification;
 import com.zero.bwtableback.reservation.entity.NotificationStatus;
-import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -25,5 +25,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Page<Long> findIdsBySentTimeBeforeAndStatus(@Param("cutoffDate") LocalDateTime cutoffDate,
                                                 @Param("status") NotificationStatus status,
                                                 Pageable pageable);
+
+    // 특정 알림 id보다 더 큰 값의 id를 가진 알림 목록 조회
+    List<Notification> findByReservation_Member_IdAndIdGreaterThan(Long id, Long memberId);
 
 }

--- a/src/main/java/com/zero/bwtableback/reservation/repository/NotificationRepository.java
+++ b/src/main/java/com/zero/bwtableback/reservation/repository/NotificationRepository.java
@@ -2,11 +2,13 @@ package com.zero.bwtableback.reservation.repository;
 
 import com.zero.bwtableback.reservation.entity.Notification;
 import com.zero.bwtableback.reservation.entity.NotificationStatus;
+import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
@@ -18,7 +20,10 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Page<Notification> findByReservation_Restaurant_Member_IdAndStatusOrderByScheduledTimeDesc(
             Long memberId, NotificationStatus status, Pageable pageable);
 
-    // cutoffDate(기준일) 지난 알림 조회
-    List<Notification> findBySentTimeBeforeAndStatus(LocalDateTime cutoffDate, NotificationStatus status);
+    // cutoffDate(기준일) 지난 알림의 ID만 조회
+    @Query("SELECT n.id FROM Notification n WHERE n.sentTime < :cutoffDate AND n.status = :status")
+    Page<Long> findIdsBySentTimeBeforeAndStatus(@Param("cutoffDate") LocalDateTime cutoffDate,
+                                                @Param("status") NotificationStatus status,
+                                                Pageable pageable);
 
 }

--- a/src/main/java/com/zero/bwtableback/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/zero/bwtableback/reservation/repository/ReservationRepository.java
@@ -6,11 +6,13 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface ReservationRepository extends JpaRepository<Reservation, Long>, JpaSpecificationExecutor<Reservation> {
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
-    List<Reservation> findByReservationDate(LocalDate reservationDate);
+    @Query("SELECT r FROM Reservation r WHERE r.reservationDate = :date")
+    List<Reservation> findReservationsByDate(@Param("date") LocalDate date);
 
     Page<Reservation> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/com/zero/bwtableback/reservation/scheduler/NotificationJobScheduler.java
+++ b/src/main/java/com/zero/bwtableback/reservation/scheduler/NotificationJobScheduler.java
@@ -19,24 +19,22 @@ public class NotificationJobScheduler {
     private final Job deleteOldNotificationsJob;
 
     @Scheduled(cron = "0 0 8 * * ?") // 매일 아침 8시에 실행
-    public void scheduleSendDayOfVisitNotifications() throws JobExecutionException {
+    public void scheduleSendDayOfVisitNotifications() {
         try {
             jobLauncher.run(sendDayOfVisitNotificationJob, new JobParameters());
             log.info("당일 예약 알림 전송을 성공적으로 완료했습니다.");
         } catch (Exception e) {
-            log.error("당일 예약 알림 전송이 실패했습니다", e);
-            throw new JobExecutionException("당일 예약 알림 전송이 실패했습니다.", e);
+            log.error("당일 예약 알림 전송이 실패했습니다.", e);
         }
     }
 
     @Scheduled(cron = "0 0 0 * * ?") // 매일 자정에 실행
-    public void scheduleDeleteOldNotifications() throws JobExecutionException {
+    public void scheduleDeleteOldNotifications() {
         try {
             jobLauncher.run(deleteOldNotificationsJob, new JobParameters());
             log.info("일주일 지난 알림 삭제를 성공적으로 완료했습니다.");
         } catch (Exception e) {
             log.error("일주일 지난 알림 삭제가 실패했습니다.", e);
-            throw new JobExecutionException("일주일 지난 알림 삭제가 실패했습니다.", e);
         }
     }
 

--- a/src/main/java/com/zero/bwtableback/reservation/scheduler/NotificationJobScheduler.java
+++ b/src/main/java/com/zero/bwtableback/reservation/scheduler/NotificationJobScheduler.java
@@ -1,0 +1,43 @@
+package com.zero.bwtableback.reservation.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecutionException;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class NotificationJobScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job sendDayOfVisitNotificationJob;
+    private final Job deleteOldNotificationsJob;
+
+    @Scheduled(cron = "0 0 8 * * ?") // 매일 아침 8시에 실행
+    public void scheduleSendDayOfVisitNotifications() throws JobExecutionException {
+        try {
+            jobLauncher.run(sendDayOfVisitNotificationJob, new JobParameters());
+            log.info("당일 예약 알림 전송을 성공적으로 완료했습니다.");
+        } catch (Exception e) {
+            log.error("당일 예약 알림 전송이 실패했습니다", e);
+            throw new JobExecutionException("당일 예약 알림 전송이 실패했습니다.", e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 자정에 실행
+    public void scheduleDeleteOldNotifications() throws JobExecutionException {
+        try {
+            jobLauncher.run(deleteOldNotificationsJob, new JobParameters());
+            log.info("일주일 지난 알림 삭제를 성공적으로 완료했습니다.");
+        } catch (Exception e) {
+            log.error("일주일 지난 알림 삭제가 실패했습니다.", e);
+            throw new JobExecutionException("일주일 지난 알림 삭제가 실패했습니다.", e);
+        }
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
@@ -29,8 +29,7 @@ public class NotificationEmitterService {
         String emitterId = memberId + "_" + System.currentTimeMillis();
         SseEmitter emitter = new SseEmitter(3_600_000L); // 기본 타임아웃 한 시간으로 설정
 
-        // Emitter 저장
-        emitterRepository.saveEmitter(emitterId, emitter, memberId);
+        emitterRepository.saveEmitter(emitterId, emitter);
 
         // 마지막 알림 이후의 알림부터 전송
         long lastEventIdLong = parseLastEventId(lastEventId);
@@ -52,7 +51,7 @@ public class NotificationEmitterService {
         sendNotificationToConnectedUser(ownerId, notification);
     }
 
-    // 모든 로그인한 기기에 전송
+    // 회원의 활성화된 emitter에 알림 전송
     public void sendNotificationToConnectedUser(Long memberId, Notification notification) {
         List<String> emitterIds = emitterRepository.findAllEmitterIdsByMemberId(memberId);
         String jsonMessage = createNotificationMessage(notification);

--- a/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
@@ -1,0 +1,105 @@
+package com.zero.bwtableback.reservation.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zero.bwtableback.common.exception.CustomException;
+import com.zero.bwtableback.common.exception.ErrorCode;
+import com.zero.bwtableback.reservation.entity.Notification;
+import com.zero.bwtableback.reservation.repository.EmitterRepository;
+import com.zero.bwtableback.reservation.repository.NotificationRepository;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class NotificationEmitterService {
+
+    private final ObjectMapper objectMapper;
+    private final EmitterRepository emitterRepository;
+    private final NotificationRepository notificationRepository;
+
+    // 사용자가 서버와 SSE 연결을 설정할 때 호출
+    public SseEmitter subscribe(Long memberId, String lastEventId) {
+        String emitterId = memberId + "_" + System.currentTimeMillis();
+        SseEmitter emitter = new SseEmitter(3_600_000L); // 기본 타임아웃 한 시간으로 설정
+
+        // Emitter 저장
+        emitterRepository.saveEmitter(emitterId, emitter, memberId);
+
+        // 마지막 알림 이후의 알림부터 전송
+        long lastEventIdLong = parseLastEventId(lastEventId);
+        if (lastEventIdLong > 0) {
+            List<Notification> missedNotifications = notificationRepository
+                    .findByReservation_Member_IdAndIdGreaterThan(memberId, lastEventIdLong);
+            missedNotifications.forEach(notification -> sendNotificationToConnectedUser(memberId, notification));
+        }
+
+        emitter.onCompletion(() -> emitterRepository.removeEmitter(emitterId));
+        emitter.onTimeout(() -> emitterRepository.removeEmitter(emitterId));
+
+        return emitter;
+    }
+
+    // 동일한 알림을 고객과 가게 주인에게 모두 전송
+    public void sendNotificationToCustomerAndOwner(Long customerId, Long ownerId, Notification notification) {
+        sendNotificationToConnectedUser(customerId, notification);
+        sendNotificationToConnectedUser(ownerId, notification);
+    }
+
+    // 모든 로그인한 기기에 전송
+    public void sendNotificationToConnectedUser(Long memberId, Notification notification) {
+        List<String> emitterIds = emitterRepository.findAllEmitterIdsByMemberId(memberId);
+        String jsonMessage = createNotificationMessage(notification);
+
+        emitterIds.forEach(emitterId -> {
+            SseEmitter emitter = emitterRepository.findById(emitterId);
+            if (emitter != null) {
+                sendMessageByEmitter(emitter, emitterId, jsonMessage);
+            }
+        });
+    }
+
+    // 해당 emitter로 메시지 전송
+    private void sendMessageByEmitter(SseEmitter emitter, String emitterId, String message) {
+        try {
+            emitter.send(SseEmitter.event()
+                    .name("reservation-notification")
+                    .id(emitterId) // 이벤트 ID를 emitterId로 설정
+                    .data(message));
+        } catch (Exception e) {
+            log.error("알림 전송이 실패했습니다. {}: {}", emitterId, e.getMessage());
+            emitter.completeWithError(e); // 연결 종료
+            emitterRepository.removeEmitter(emitterId); // emitter 제거
+        }
+    }
+
+    // 전달 받은 마지막 알림 아이디가 있으면 파싱하고 없으면 0으로 설정
+    private long parseLastEventId(String lastEventId) {
+        if (lastEventId != null && !lastEventId.isEmpty()) {
+            return Long.parseLong(lastEventId);
+        }
+        return 0L;
+    }
+
+    // Notification 객체를 JSON 문자열로 변환하는 메서드
+    private String createNotificationMessage(Notification notification) {
+        Map<String, Object> notificationData = new HashMap<>();
+        notificationData.put("message", notification.getMessage());
+        notificationData.put("customerId", notification.getReservation().getMember().getId());
+        notificationData.put("ownerId", notification.getReservation().getRestaurant().getMember().getId());
+        notificationData.put("reservationId", notification.getReservation().getId());
+        notificationData.put("status", notification.getStatus());
+
+        try {
+            return objectMapper.writeValueAsString(notificationData);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.JSON_PARSING_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/zero/bwtableback/reservation/service/ReservationService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/ReservationService.java
@@ -80,7 +80,7 @@ public class ReservationService {
         }
 
         if (statusUpdateDto.reservationStatus() == null) {
-//          FIXME  throw new CustomException(ErrorCode.INVALID_RESERVATION_STATUS);
+          throw new CustomException(ErrorCode.INVALID_RESERVATION_STATUS);
         }
 
         ReservationStatus newStatus = statusUpdateDto.reservationStatus();
@@ -90,8 +90,7 @@ public class ReservationService {
             case OWNER_CANCELED -> handleOwnerCanceledStatus(reservation);
             case NO_SHOW -> handleNoShowStatus(reservation);
             case VISITED -> handleVisitedStatus(reservation);
-//          FIXME  default -> throw new CustomException(ErrorCode.INVALID_RESERVATION_STATUS);
-            default -> throw new RuntimeException("INVALID_RESERVATION_STATUS");
+            default -> throw new CustomException(ErrorCode.INVALID_RESERVATION_STATUS);
         };
     }
 

--- a/src/test/java/com/zero/bwtableback/reservation/service/NotificationEmitterServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/reservation/service/NotificationEmitterServiceTest.java
@@ -64,7 +64,7 @@ public class NotificationEmitterServiceTest {
         // then
         assertThat(result).isNotNull();
         verify(emitterRepository, times(1))
-                .saveEmitter(anyString(), any(SseEmitter.class), eq(memberId));
+                .saveEmitter(anyString(), any(SseEmitter.class));
         verify(notificationRepository, times(1))
                 .findByReservation_Member_IdAndIdGreaterThan(eq(memberId), anyLong());
     }
@@ -97,7 +97,7 @@ public class NotificationEmitterServiceTest {
         Long memberId = 1L;
 
         // mocking
-        doNothing().when(emitterRepository).saveEmitter(anyString(), any(SseEmitter.class), eq(memberId));
+        doNothing().when(emitterRepository).saveEmitter(anyString(), any(SseEmitter.class));
 
         // when
         SseEmitter resultForNullId = notificationEmitterService.subscribe(memberId, null);
@@ -106,7 +106,7 @@ public class NotificationEmitterServiceTest {
         // then
         assertThat(resultForNullId).isNotNull();
         assertThat(resultForEmptyId).isNotNull();
-        verify(emitterRepository, times(2)).saveEmitter(anyString(), any(SseEmitter.class), eq(memberId));
+        verify(emitterRepository, times(2)).saveEmitter(anyString(), any(SseEmitter.class));
     }
 
     private Notification createMockNotification(Long memberId, Long ownerId) {
@@ -135,7 +135,7 @@ public class NotificationEmitterServiceTest {
     }
 
     private void mockEmitterRepositoryForSubscription(Long memberId, String emitterId) {
-        doNothing().when(emitterRepository).saveEmitter(anyString(), any(SseEmitter.class), eq(memberId));
+        doNothing().when(emitterRepository).saveEmitter(anyString(), any(SseEmitter.class));
         given(emitterRepository.findAllEmitterIdsByMemberId(memberId)).willReturn(List.of(emitterId));
     }
 

--- a/src/test/java/com/zero/bwtableback/reservation/service/NotificationEmitterServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/reservation/service/NotificationEmitterServiceTest.java
@@ -1,0 +1,142 @@
+package com.zero.bwtableback.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zero.bwtableback.member.entity.Member;
+import com.zero.bwtableback.reservation.entity.Notification;
+import com.zero.bwtableback.reservation.entity.Reservation;
+import com.zero.bwtableback.reservation.repository.EmitterRepository;
+import com.zero.bwtableback.reservation.repository.NotificationRepository;
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import java.io.IOException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationEmitterServiceTest {
+
+    @Mock
+    private ObjectMapper objectMapper;
+
+    @Mock
+    private EmitterRepository emitterRepository;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @InjectMocks
+    private NotificationEmitterService notificationEmitterService;
+
+    @DisplayName("SSE 연결을 저장하고 lastEventId 기준으로 알림 조회를 시도한다")
+    @Test
+    void givenMemberIdAndLastEventId_whenSubscribe_thenSavesEmitterAndSendsMissedNotifications() {
+        // given
+        Long memberId = 1L;
+        String lastEventId = "123";
+        Long ownerId = 2L;
+
+        Notification notification = createMockNotification(memberId, ownerId);
+        mockObjectMapperForJson();
+        mockEmitterRepositoryForSubscription(memberId, "1_12345");
+
+        given(notificationRepository.findByReservation_Member_IdAndIdGreaterThan(eq(memberId), anyLong()))
+                .willReturn(List.of(notification));
+
+        // when
+        SseEmitter result = notificationEmitterService.subscribe(memberId, lastEventId);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(emitterRepository, times(1))
+                .saveEmitter(anyString(), any(SseEmitter.class), eq(memberId));
+        verify(notificationRepository, times(1))
+                .findByReservation_Member_IdAndIdGreaterThan(eq(memberId), anyLong());
+    }
+
+    @DisplayName("연결된 emitter를 조회하고 메시지 생성 메서드를 호출한다")
+    @Test
+    void givenMemberIdAndNotification_whenSendNotificationToConnectedUser_thenCreatesJsonMessageAndSendsToEmitters() {
+        // given
+        Long memberId = 1L;
+        Long ownerId = 2L;
+        Notification notification = createMockNotification(memberId, ownerId);
+        String emitterId = "1_12345";
+        SseEmitter emitter = new SseEmitter(3_600_000L);
+
+        given(emitterRepository.findById(emitterId)).willReturn(emitter);
+        given(emitterRepository.findAllEmitterIdsByMemberId(memberId)).willReturn(List.of(emitterId));
+
+        // when
+        notificationEmitterService.sendNotificationToConnectedUser(memberId, notification);
+
+        // then
+        verify(emitterRepository, times(1)).findAllEmitterIdsByMemberId(memberId);
+        verify(emitterRepository, times(1)).findById(emitterId);
+    }
+
+    @DisplayName("기본 Last-Event-ID를 설정하고 SSE 연결을 저장한다")
+    @Test
+    void givenNullOrEmptyLastEventId_whenSubscribe_thenSetsDefaultLastEventId() {
+        // given
+        Long memberId = 1L;
+
+        // mocking
+        doNothing().when(emitterRepository).saveEmitter(anyString(), any(SseEmitter.class), eq(memberId));
+
+        // when
+        SseEmitter resultForNullId = notificationEmitterService.subscribe(memberId, null);
+        SseEmitter resultForEmptyId = notificationEmitterService.subscribe(memberId, "");
+
+        // then
+        assertThat(resultForNullId).isNotNull();
+        assertThat(resultForEmptyId).isNotNull();
+        verify(emitterRepository, times(2)).saveEmitter(anyString(), any(SseEmitter.class), eq(memberId));
+    }
+
+    private Notification createMockNotification(Long memberId, Long ownerId) {
+        Notification notification = mock(Notification.class);
+        Reservation reservation = mock(Reservation.class);
+        Member customer = mock(Member.class);
+        Member owner = mock(Member.class);
+        Restaurant restaurant = mock(Restaurant.class);
+
+        given(notification.getReservation()).willReturn(reservation);
+        given(reservation.getMember()).willReturn(customer);
+        given(customer.getId()).willReturn(memberId);
+        given(reservation.getRestaurant()).willReturn(restaurant);
+        given(restaurant.getMember()).willReturn(owner);
+        given(owner.getId()).willReturn(ownerId);
+
+        return notification;
+    }
+
+    private void mockObjectMapperForJson() {
+        try {
+            given(objectMapper.writeValueAsString(any())).willReturn("{\"message\":\"test\"}");
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void mockEmitterRepositoryForSubscription(Long memberId, String emitterId) {
+        doNothing().when(emitterRepository).saveEmitter(anyString(), any(SseEmitter.class), eq(memberId));
+        given(emitterRepository.findAllEmitterIdsByMemberId(memberId)).willReturn(List.of(emitterId));
+    }
+
+}

--- a/src/test/java/com/zero/bwtableback/reservation/service/NotificationScheduleServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/reservation/service/NotificationScheduleServiceTest.java
@@ -1,0 +1,244 @@
+package com.zero.bwtableback.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.zero.bwtableback.common.exception.CustomException;
+import com.zero.bwtableback.common.exception.ErrorCode;
+import com.zero.bwtableback.member.entity.Member;
+import com.zero.bwtableback.reservation.entity.Notification;
+import com.zero.bwtableback.reservation.entity.NotificationStatus;
+import com.zero.bwtableback.reservation.entity.NotificationType;
+import com.zero.bwtableback.reservation.entity.Reservation;
+import com.zero.bwtableback.reservation.repository.NotificationRepository;
+import com.zero.bwtableback.reservation.util.NotificationMessageGenerator;
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationScheduleServiceTest {
+
+    @InjectMocks
+    private NotificationScheduleService notificationScheduleService;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private NotificationEmitterService notificationEmitterService;
+
+    @DisplayName("예약 확정 시 즉시 알림을 생성하고 전송한다")
+    @Test
+    void givenReservationAndType_whenScheduleImmediateNotification_thenCreateAndSendNotification() {
+        // given
+        Reservation reservation = mock(Reservation.class);
+        Restaurant restaurant = mock(Restaurant.class);
+        Member customerMember = mock(Member.class);
+        Member ownerMember = mock(Member.class);
+        Notification notification = mock(Notification.class);
+        String message = "알림 메시지 예시";
+
+        LocalDateTime scheduledTime = LocalDateTime.now().minusMinutes(5); // 과거 시간 설정
+
+        given(reservation.getMember()).willReturn(customerMember);
+        given(reservation.getRestaurant()).willReturn(restaurant);
+        given(restaurant.getMember()).willReturn(ownerMember);
+        given(customerMember.getId()).willReturn(1L);
+        given(ownerMember.getId()).willReturn(2L);
+        given(notification.getReservation()).willReturn(reservation);
+        given(notification.getScheduledTime()).willReturn(scheduledTime);
+
+        try (MockedStatic<NotificationMessageGenerator> mockedGenerator = Mockito.mockStatic(NotificationMessageGenerator.class)) {
+            mockedGenerator.when(() -> NotificationMessageGenerator.generateMessage(reservation, NotificationType.CONFIRMATION))
+                    .thenReturn(message);
+
+            given(notificationRepository.save(any(Notification.class))).willReturn(notification);
+            doNothing().when(notificationEmitterService).sendNotificationToCustomerAndOwner(any(), any(), any());
+
+            // when
+            notificationScheduleService.scheduleImmediateNotification(reservation, NotificationType.CONFIRMATION);
+
+            // then
+            verify(notificationRepository).save(any(Notification.class));
+            verify(notificationEmitterService).sendNotificationToCustomerAndOwner(any(), any(), any());
+            verify(notification).setSentTime(any(LocalDateTime.class));
+        }
+    }
+
+    @DisplayName("예약 24시간 전 알림을 스케줄링한다")
+    @Test
+    void givenReservation_whenSchedule24HoursBeforeNotification_thenScheduleNotification() {
+        // given
+        Reservation reservation = mock(Reservation.class);
+        Member customerMember = mock(Member.class);
+        Member ownerMember = mock(Member.class);
+        Restaurant restaurant = mock(Restaurant.class);
+
+        given(reservation.getMember()).willReturn(customerMember);
+        given(reservation.getRestaurant()).willReturn(restaurant);
+        given(restaurant.getMember()).willReturn(ownerMember);
+        given(ownerMember.getId()).willReturn(1L);
+
+        // 예약 날짜와 시간을 설정
+        LocalDate reservationDate = LocalDate.now().plusDays(1);
+        LocalTime reservationTime = LocalTime.of(12, 0);
+        LocalDateTime reservationDateTime = LocalDateTime.of(reservationDate, reservationTime);
+        LocalDateTime expectedScheduleTime = reservationDateTime.minusHours(24);
+
+        given(reservation.getReservationDate()).willReturn(reservationDate);
+        given(reservation.getReservationTime()).willReturn(reservationTime);
+
+        try (MockedStatic<NotificationMessageGenerator> mockedGenerator = Mockito.mockStatic(NotificationMessageGenerator.class)) {
+            mockedGenerator.when(() -> NotificationMessageGenerator.generateMessage(any(Reservation.class), any(NotificationType.class)))
+                    .thenReturn("알림 메시지 예시");
+
+            Notification notification = Notification.builder()
+                    .reservation(reservation)
+                    .notificationType(NotificationType.REMINDER_24H)
+                    .message("알림 메시지 예시")
+                    .scheduledTime(LocalDateTime.now())
+                    .status(NotificationStatus.PENDING)
+                    .build();
+
+            given(notificationRepository.save(any(Notification.class))).willReturn(notification);
+
+            ArgumentCaptor<Instant> instantCaptor = ArgumentCaptor.forClass(Instant.class);
+
+            // when
+            notificationScheduleService.schedule24HoursBeforeNotification(reservation);
+
+            // then
+            verify(taskScheduler).schedule(any(Runnable.class), instantCaptor.capture());
+
+            Instant capturedInstant = instantCaptor.getValue();
+            Instant expectedInstant = expectedScheduleTime.atZone(ZoneId.systemDefault()).toInstant();
+
+            assertThat(capturedInstant).isEqualTo(expectedInstant);
+        }
+    }
+
+    @DisplayName("예약 상태에 따라 알림을 생성하고 저장한다")
+    @Test
+    void givenReservationAndNotificationType_whenCreateAndSaveNotification_thenNotificationIsSaved() {
+        // given
+        Reservation reservation = mock(Reservation.class);
+        NotificationType type = NotificationType.REMINDER_24H;
+        String message = "알림 메시지 예시";
+
+        try (MockedStatic<NotificationMessageGenerator> mockedGenerator = Mockito.mockStatic(NotificationMessageGenerator.class)) {
+            mockedGenerator.when(() -> NotificationMessageGenerator.generateMessage(reservation, type)).thenReturn(message);
+
+            Notification notification = Notification.builder()
+                    .reservation(reservation)
+                    .notificationType(type)
+                    .message(message)
+                    .scheduledTime(LocalDateTime.now())
+                    .status(NotificationStatus.PENDING)
+                    .build();
+
+            given(notificationRepository.save(any(Notification.class))).willReturn(notification);
+
+            // when
+            Notification savedNotification = notificationScheduleService.createAndSaveNotification(reservation, type);
+
+            // then
+            assertThat(savedNotification).isNotNull();
+            assertThat(savedNotification.getMessage()).isEqualTo(message);
+            verify(notificationRepository).save(any(Notification.class));
+        }
+    }
+
+    @DisplayName("이미 전송된 알림을 다시 전송 시도하면 예외를 발생시킨다")
+    @Test
+    void givenAlreadySentNotification_whenImmediateNotificationScheduled_thenThrowException() {
+        // given
+        Reservation reservation = mock(Reservation.class);
+        Member customerMember = mock(Member.class);
+        Member ownerMember = mock(Member.class);
+        Restaurant restaurant = mock(Restaurant.class);
+
+        given(reservation.getMember()).willReturn(customerMember);
+        given(reservation.getRestaurant()).willReturn(restaurant);
+        given(restaurant.getMember()).willReturn(ownerMember);
+
+        Notification notification = Notification.builder()
+                .reservation(reservation)
+                .notificationType(NotificationType.CONFIRMATION)
+                .message("알림 메시지 예시")
+                .scheduledTime(LocalDateTime.now())
+                .status(NotificationStatus.SENT) // 이미 전송된 상태로 설정
+                .build();
+
+        given(notificationRepository.save(any(Notification.class))).willReturn(notification);
+
+        try (MockedStatic<NotificationMessageGenerator> mockedGenerator = Mockito.mockStatic(NotificationMessageGenerator.class)) {
+            mockedGenerator.when(() -> NotificationMessageGenerator.generateMessage(any(Reservation.class), any(NotificationType.class)))
+                    .thenReturn("알림 메시지 예시");
+
+            // when & then
+            assertThatThrownBy(() -> notificationScheduleService.scheduleImmediateNotification(reservation, NotificationType.CONFIRMATION))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTIFICATION_ALREADY_SENT);
+        }
+    }
+
+    @DisplayName("예정된 시간 전에 알림 전송을 시도하면 예외를 발생시킨다")
+    @Test
+    void givenNotificationWithFutureScheduledTime_whenImmediateNotificationScheduled_thenThrowException() {
+        // given
+        Reservation reservation = mock(Reservation.class);
+        Member customerMember = mock(Member.class);
+        Member ownerMember = mock(Member.class);
+        Restaurant restaurant = mock(Restaurant.class);
+
+        given(reservation.getMember()).willReturn(customerMember);
+        given(reservation.getRestaurant()).willReturn(restaurant);
+        given(restaurant.getMember()).willReturn(ownerMember);
+
+        // 미래 시간으로 예약 시간을 설정
+        LocalDateTime futureScheduledTime = LocalDateTime.now().plusMinutes(10);
+
+        Notification notification = Notification.builder()
+                .reservation(reservation)
+                .notificationType(NotificationType.CONFIRMATION)
+                .message("알림 메시지 예시")
+                .scheduledTime(futureScheduledTime)
+                .status(NotificationStatus.PENDING) // 아직 보내지 않은 알림으로 설정
+                .build();
+
+        given(notificationRepository.save(any(Notification.class))).willReturn(notification);
+
+        try (MockedStatic<NotificationMessageGenerator> mockedGenerator = Mockito.mockStatic(NotificationMessageGenerator.class)) {
+            mockedGenerator.when(() -> NotificationMessageGenerator.generateMessage(any(Reservation.class), any(NotificationType.class)))
+                    .thenReturn("알림 메시지 예시");
+
+            // when & then
+            assertThatThrownBy(() -> notificationScheduleService.scheduleImmediateNotification(reservation, NotificationType.CONFIRMATION))
+                    .isInstanceOf(CustomException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NOTIFICATION_SCHEDULED_TIME_NOT_REACHED);
+        }
+    }
+
+}


### PR DESCRIPTION
### 변경 사항
- [X] 신규 기능 추가 
- [X] 리펙토링
- [X] 테스트 

### 작업 내역
[당일 예약 알림과 일주일 지난 알림 삭제 기능]
- 방문 당일 예약 알림과 일주일 지난 알림 삭제 처리를 위해 Batch Job 설정을 추가했습니다.
- 방문 당일 예약 알림 작업: 당일 예약을 읽고 알림을 생성 후 전송합니다.
- 일주일 지난 알림 삭제 작업: 일주일 전 알림을 읽고 삭제합니다.
- 스케쥴링: 당일 예약 알림은 매일 오전 8시, 일주일 지난 알림 삭제는 매일 자정에 실행됩니다.
- 두 작업은 현재 50개 단위로 데이터를 읽고 처리를 진행하도록 설정되어 있는데, 조정이 필요하면 의견 주세요.

[실시간 알림 전송 기능]
- SSE를 사용해 단방향 통신으로 실시간 알림을 전송하는 기능을 구현했습니다.
- 동일 사용자가 여러 기기로 로그인한 경우에도 기기 별로 emitter를 생성해서 모든 기기에 알림을 전송합니다.
- 클라이언트가 마지막으로 받은 알림 id를 `lastEventId`를 전달하면 알림 조회에 사용됩니다.
- 고객과 가게 주인 모두에게 동일한 예약 관련 알림을 전송합니다.
- 클라이언트가 SSE 연결로 실시간 데이터를 수신하는 `/subscribe`엔드포인트를 생성했습니다.
- 사용자 인증 정보를 받아와 해당 사용자에 대한 알림을 전송합니다.
- `Last-Event-ID` 헤더를 추가해 클라이언트가 마지막 읽은 알림 id를 헤더로 전달할 수 있습니다.

### 테스트
- [X] 테스트 추가
- [X] 모든 테스트가 통과

## 참고
closes #65 
