### PR TITLE
통계 차트에 필요한 데이터 반환 기능 구현

### DIFF
--- a/src/main/java/com/zero/bwtableback/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/zero/bwtableback/reservation/repository/ReservationRepository.java
@@ -4,6 +4,11 @@ import com.zero.bwtableback.member.entity.Member;
 import com.zero.bwtableback.reservation.entity.Reservation;
 import com.zero.bwtableback.reservation.entity.ReservationStatus;
 import com.zero.bwtableback.restaurant.entity.Restaurant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import com.zero.bwtableback.reservation.entity.ReservationStatus;
+import com.zero.bwtableback.restaurant.entity.Restaurant;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -46,4 +51,50 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByRestaurantIdAndReservationDate(Long restaurantId, LocalDate reservationDate);
 
     Reservation findTopByMemberOrderByReservationDateDesc(Member member);
+
+    // 일별 예약 조회
+    @Query("""
+                SELECT r.reservationDate, COUNT(r)
+                FROM Reservation r
+                WHERE r.restaurant.id = :restaurantId
+                  AND r.reservationDate BETWEEN :startDate AND :endDate
+                  AND r.reservationStatus = 'VISITED'
+                GROUP BY r.reservationDate
+            """)
+    List<Object[]> aggregateDailyStatistics(Long restaurantId, LocalDate startDate, LocalDate endDate);
+
+    // 주별 예약 조회
+    @Query("""
+                SELECT FUNCTION('YEARWEEK', r.reservationDate), COUNT(r)
+                FROM Reservation r
+                WHERE r.restaurant.id = :restaurantId
+                  AND r.reservationDate BETWEEN :startDate AND :endDate
+                  AND r.reservationStatus = 'VISITED'
+                GROUP BY FUNCTION('YEARWEEK', r.reservationDate)
+            """)
+    List<Object[]> aggregateWeeklyStatistics(Long restaurantId, LocalDate startDate, LocalDate endDate);
+
+    // 월별 예약 조회
+    @Query("""
+                SELECT FUNCTION('YEAR_MONTH', r.reservationDate), COUNT(r)
+                FROM Reservation r
+                WHERE r.restaurant.id = :restaurantId
+                  AND r.reservationDate BETWEEN :startDate AND :endDate
+                  AND r.reservationStatus = 'VISITED'
+                GROUP BY FUNCTION('YEAR_MONTH', r.reservationDate)
+            """)
+    List<Object[]> aggregateMonthlyStatistics(Long restaurantId, LocalDate startDate, LocalDate endDate);
+
+    // 인기 시간대 조회
+    @Query("""
+                SELECT r.reservationTime, COUNT(r)
+                FROM Reservation r
+                WHERE r.restaurant.id = :restaurantId
+                  AND r.reservationDate BETWEEN :startDate AND :endDate
+                  AND r.reservationStatus = 'VISITED'
+                GROUP BY r.reservationTime
+                ORDER BY COUNT(r) DESC
+            """)
+    List<Object[]> aggregateTimeSlotStatistics(Long restaurantId, LocalDate startDate, LocalDate endDate);
+
 }

--- a/src/main/java/com/zero/bwtableback/statistics/batch/StatisticsBatchConfig.java
+++ b/src/main/java/com/zero/bwtableback/statistics/batch/StatisticsBatchConfig.java
@@ -1,0 +1,144 @@
+package com.zero.bwtableback.statistics.batch;
+
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import com.zero.bwtableback.restaurant.repository.RestaurantRepository;
+import com.zero.bwtableback.statistics.batch.processor.DailyStatisticsProcessor;
+import com.zero.bwtableback.statistics.batch.processor.MonthlyStatisticsProcessor;
+import com.zero.bwtableback.statistics.batch.processor.PopularDatesProcessor;
+import com.zero.bwtableback.statistics.batch.processor.PopularTimeSlotsProcessor;
+import com.zero.bwtableback.statistics.batch.processor.WeeklyStatisticsProcessor;
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.repository.StatisticsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemReader;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.support.ListItemReader;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@RequiredArgsConstructor
+@EnableBatchProcessing
+@Configuration
+public class StatisticsBatchConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    private final RestaurantRepository restaurantRepository;
+    private final StatisticsRepository statisticsRepository;
+
+    private final DailyStatisticsProcessor dailyStatisticsProcessor;
+    private final WeeklyStatisticsProcessor weeklyStatisticsProcessor;
+    private final MonthlyStatisticsProcessor monthlyStatisticsProcessor;
+    private final PopularTimeSlotsProcessor popularTimeSlotsProcessor;
+    private final PopularDatesProcessor popularDatesProcessor;
+
+
+    @Bean
+    public Job dailyStatisticsJob(Step dailyStatisticsStep) {
+        return new JobBuilder("dailyStatisticsJob", jobRepository)
+                .start(dailyStatisticsStep)
+                .build();
+    }
+
+    @Bean
+    public Job weeklyStatisticsJob(Step weeklyStatisticsStep) {
+        return new JobBuilder("weeklyStatisticsJob", jobRepository)
+                .start(weeklyStatisticsStep)
+                .build();
+    }
+
+    @Bean
+    public Job monthlyStatisticsJob(Step monthlyStatisticsStep) {
+        return new JobBuilder("monthlyStatisticsJob", jobRepository)
+                .start(monthlyStatisticsStep)
+                .build();
+    }
+
+    @Bean
+    public Job popularTimeSlotsJob(Step popularTimeSlotsStep) {
+        return new JobBuilder("popularTimeSlotsJob", jobRepository)
+                .start(popularTimeSlotsStep)
+                .build();
+    }
+
+    @Bean
+    public Job popularDatesJob(Step popularDatesStep) {
+        return new JobBuilder("popularDatesJob", jobRepository)
+                .start(popularDatesStep)
+                .build();
+    }
+
+
+    @Bean
+    public Step dailyStatisticsStep() {
+        return new StepBuilder("dailyStatisticsStep", jobRepository)
+                .<Restaurant, List<Statistics>>chunk(100, transactionManager)
+                .reader(restaurantReader())
+                .processor(dailyStatisticsProcessor)
+                .writer(statisticsWriter())
+                .build();
+    }
+
+    @Bean
+    public Step weeklyStatisticsStep() {
+        return new StepBuilder("weeklyStatisticsStep", jobRepository)
+                .<Restaurant, List<Statistics>>chunk(100, transactionManager)
+                .reader(restaurantReader())
+                .processor(weeklyStatisticsProcessor)
+                .writer(statisticsWriter())
+                .build();
+    }
+
+    @Bean
+    public Step monthlyStatisticsStep() {
+        return new StepBuilder("monthlyStatisticsStep", jobRepository)
+                .<Restaurant, List<Statistics>>chunk(100, transactionManager)
+                .reader(restaurantReader())
+                .processor(monthlyStatisticsProcessor)
+                .writer(statisticsWriter())
+                .build();
+    }
+
+    @Bean
+    public Step popularTimeSlotsStep() {
+        return new StepBuilder("popularTimeSlotsStep", jobRepository)
+                .<Restaurant, List<Statistics>>chunk(100, transactionManager)
+                .reader(restaurantReader())
+                .processor(popularTimeSlotsProcessor)
+                .writer(statisticsWriter())
+                .build();
+    }
+
+    @Bean
+    public Step popularDatesStep() {
+        return new StepBuilder("popularDatesStep", jobRepository)
+                .<Restaurant, List<Statistics>>chunk(100, transactionManager)
+                .reader(restaurantReader())
+                .processor(popularDatesProcessor)
+                .writer(statisticsWriter())
+                .build();
+    }
+
+
+    @Bean
+    public ItemReader<Restaurant> restaurantReader() {
+        return new ListItemReader<>(restaurantRepository.findAll());
+    }
+
+    @Bean
+    public ItemWriter<List<Statistics>> statisticsWriter() {
+        return items -> items.getItems().stream()
+                .flatMap(List::stream)
+                .forEach(statisticsRepository::save);
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/statistics/batch/processor/DailyStatisticsProcessor.java
+++ b/src/main/java/com/zero/bwtableback/statistics/batch/processor/DailyStatisticsProcessor.java
@@ -1,0 +1,37 @@
+package com.zero.bwtableback.statistics.batch.processor;
+
+import com.zero.bwtableback.reservation.repository.ReservationRepository;
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.entity.StatisticsType;
+import com.zero.bwtableback.statistics.util.PeriodKeyGenerator;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class DailyStatisticsProcessor implements ItemProcessor<Restaurant, List<Statistics>> {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public List<Statistics> process(@NonNull Restaurant restaurant) {
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = today.minusDays(1);
+        LocalDate startDate = endDate.minusDays(30);
+
+        List<Object[]> results = reservationRepository.aggregateDailyStatistics(restaurant.getId(), startDate, endDate);
+        return results.stream()
+                .map(result -> Statistics.builder()
+                        .restaurant(restaurant)
+                        .type(StatisticsType.DAILY)
+                        .timeKey(PeriodKeyGenerator.generateDailyKey((LocalDate) result[0])) // YYYY-MM-DD
+                        .reservationCount(Integer.parseInt(result[1].toString()))
+                        .build()
+                ).toList();
+    }
+}

--- a/src/main/java/com/zero/bwtableback/statistics/batch/processor/MonthlyStatisticsProcessor.java
+++ b/src/main/java/com/zero/bwtableback/statistics/batch/processor/MonthlyStatisticsProcessor.java
@@ -1,0 +1,38 @@
+package com.zero.bwtableback.statistics.batch.processor;
+
+import com.zero.bwtableback.reservation.repository.ReservationRepository;
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.entity.StatisticsType;
+import com.zero.bwtableback.statistics.util.DateRangeCalculator;
+import com.zero.bwtableback.statistics.util.PeriodKeyGenerator;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class MonthlyStatisticsProcessor implements ItemProcessor<Restaurant, List<Statistics>> {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public List<Statistics> process(@NonNull Restaurant restaurant) {
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = DateRangeCalculator.getEndDateForMonthRange(today);
+        LocalDate startDate = DateRangeCalculator.getStartDateForMonthRange(today);
+
+        List<Object[]> results = reservationRepository.aggregateMonthlyStatistics(restaurant.getId(), startDate, endDate);
+        return results.stream()
+                .map(result -> Statistics.builder()
+                        .restaurant(restaurant)
+                        .type(StatisticsType.MONTHLY)
+                        .timeKey(PeriodKeyGenerator.generateMonthlyKey((LocalDate) result[0])) // YYYY-MM
+                        .reservationCount(Integer.parseInt(result[1].toString()))
+                        .build()
+                ).toList();
+    }
+}

--- a/src/main/java/com/zero/bwtableback/statistics/batch/processor/PopularDatesProcessor.java
+++ b/src/main/java/com/zero/bwtableback/statistics/batch/processor/PopularDatesProcessor.java
@@ -1,0 +1,39 @@
+package com.zero.bwtableback.statistics.batch.processor;
+
+import com.zero.bwtableback.reservation.repository.ReservationRepository;
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.entity.StatisticsType;
+import com.zero.bwtableback.statistics.util.PeriodKeyGenerator;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PopularDatesProcessor implements ItemProcessor<Restaurant, List<Statistics>> {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public List<Statistics> process(@NonNull Restaurant restaurant) {
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = today.minusDays(1);
+        LocalDate startDate = endDate.minusDays(30);
+
+        List<Object[]> results = reservationRepository.aggregateDailyStatistics(restaurant.getId(), startDate, endDate);
+        return results.stream()
+                .sorted((a, b) -> Integer.compare((int) b[1], (int) a[1])) // 예약 건수를 비교해서 내림차순 정렬
+                .limit(5) // 상위 5개의 인기 일자만 선택
+                .map(result -> Statistics.builder()
+                        .restaurant(restaurant)
+                        .type(StatisticsType.POPULAR_DATE)
+                        .timeKey(PeriodKeyGenerator.generateDailyKey((LocalDate) result[0]))
+                        .reservationCount(Integer.parseInt(result[1].toString()))
+                        .build()
+                ).toList();
+    }
+}

--- a/src/main/java/com/zero/bwtableback/statistics/batch/processor/PopularTimeSlotsProcessor.java
+++ b/src/main/java/com/zero/bwtableback/statistics/batch/processor/PopularTimeSlotsProcessor.java
@@ -1,0 +1,36 @@
+package com.zero.bwtableback.statistics.batch.processor;
+
+import com.zero.bwtableback.reservation.repository.ReservationRepository;
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.entity.StatisticsType;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class PopularTimeSlotsProcessor implements ItemProcessor<Restaurant, List<Statistics>> {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public List<Statistics> process(@NonNull Restaurant restaurant) {
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = today.minusDays(1);
+        LocalDate startDate = endDate.minusDays(30);
+
+        List<Object[]> results = reservationRepository.aggregateTimeSlotStatistics(restaurant.getId(), startDate, endDate);
+        return results.stream()
+                .map(result -> Statistics.builder()
+                        .restaurant(restaurant)
+                        .type(StatisticsType.TIME_SLOT)
+                        .timeKey(result[0].toString()) // reservationTime
+                        .reservationCount(Integer.parseInt(result[1].toString()))
+                        .build()
+                ).toList();
+    }
+}

--- a/src/main/java/com/zero/bwtableback/statistics/batch/processor/WeeklyStatisticsProcessor.java
+++ b/src/main/java/com/zero/bwtableback/statistics/batch/processor/WeeklyStatisticsProcessor.java
@@ -1,0 +1,38 @@
+package com.zero.bwtableback.statistics.batch.processor;
+
+import com.zero.bwtableback.reservation.repository.ReservationRepository;
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.entity.StatisticsType;
+import com.zero.bwtableback.statistics.util.DateRangeCalculator;
+import com.zero.bwtableback.statistics.util.PeriodKeyGenerator;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class WeeklyStatisticsProcessor implements ItemProcessor<Restaurant, List<Statistics>> {
+
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public List<Statistics> process(@NonNull Restaurant restaurant) {
+        LocalDate today = LocalDate.now();
+        LocalDate endDate = DateRangeCalculator.getEndOfWeekRange(today);
+        LocalDate startDate = DateRangeCalculator.getStartOfWeekRange(endDate, 12);
+
+        List<Object[]> results = reservationRepository.aggregateWeeklyStatistics(restaurant.getId(), startDate, endDate);
+        return results.stream()
+                .map(result -> Statistics.builder()
+                        .restaurant(restaurant)
+                        .type(StatisticsType.WEEKLY)
+                        .timeKey(PeriodKeyGenerator.generateWeeklyKey((LocalDate) result[0])) // YYYY-Wxx
+                        .reservationCount(Integer.parseInt(result[1].toString()))
+                        .build()
+                ).toList();
+    }
+}

--- a/src/main/java/com/zero/bwtableback/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/zero/bwtableback/statistics/controller/StatisticsController.java
@@ -1,0 +1,44 @@
+package com.zero.bwtableback.statistics.controller;
+
+import com.zero.bwtableback.statistics.dto.StatisticsDto;
+import com.zero.bwtableback.statistics.service.StatisticsService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/statistics")
+public class StatisticsController {
+
+    private final StatisticsService statisticsService;
+
+    @GetMapping("/{restaurantId}/daily")
+    public List<StatisticsDto> getDailyReservationsLast30Days(@PathVariable Long restaurantId) {
+        return statisticsService.getDailyReservationsLast30Days(restaurantId);
+    }
+
+    @GetMapping("/{restaurantId}/weekly")
+    public List<StatisticsDto> getWeeklyReservationsLast12Weeks(@PathVariable Long restaurantId) {
+        return statisticsService.getWeeklyReservationsLast12Weeks(restaurantId);
+    }
+
+    @GetMapping("/{restaurantId}/monthly")
+    public List<StatisticsDto> getMonthlyReservationsLast6Months(@PathVariable Long restaurantId) {
+        return statisticsService.getMonthlyReservationsLast6Months(restaurantId);
+    }
+
+    @GetMapping("/{restaurantId}/popular-times")
+    public List<StatisticsDto> getPopularTimesLast30Days(@PathVariable Long restaurantId) {
+        return statisticsService.getPopularTimesLast30Days(restaurantId);
+    }
+
+    @GetMapping("/{restaurantId}/popular-dates")
+    public List<StatisticsDto> getTop5PopularDatesLast30Days(@PathVariable Long restaurantId) {
+        return statisticsService.getTop5PopularDatesLast30Days(restaurantId);
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/statistics/dto/StatisticsDto.java
+++ b/src/main/java/com/zero/bwtableback/statistics/dto/StatisticsDto.java
@@ -1,0 +1,21 @@
+package com.zero.bwtableback.statistics.dto;
+
+import com.zero.bwtableback.statistics.entity.Statistics;
+import java.util.List;
+
+public record StatisticsDto(String periodKey, int reservationCount) {
+
+    public static List<StatisticsDto> fromEntities(List<Statistics> statisticsList) {
+        return statisticsList.stream()
+                .map(StatisticsDto::fromEntity)
+                .toList();
+    }
+
+    private static StatisticsDto fromEntity(Statistics statistics) {
+        return new StatisticsDto(
+                statistics.getTimeKey(),
+                statistics.getReservationCount()
+        );
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/statistics/entity/Statistics.java
+++ b/src/main/java/com/zero/bwtableback/statistics/entity/Statistics.java
@@ -15,11 +15,11 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@Entity
 public class Statistics {
 
     @Id

--- a/src/main/java/com/zero/bwtableback/statistics/entity/Statistics.java
+++ b/src/main/java/com/zero/bwtableback/statistics/entity/Statistics.java
@@ -1,0 +1,43 @@
+package com.zero.bwtableback.statistics.entity;
+
+import com.zero.bwtableback.restaurant.entity.Restaurant;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Statistics {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(nullable = false)
+    private Restaurant restaurant;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private StatisticsType type;
+
+    @Column(nullable = false)
+    private String timeKey; // 날짜: "2024-11-01", 주: "2024-W45", 월: "2024-11"
+
+    @Column(nullable = false)
+    private int reservationCount; // 예약 건수
+
+}

--- a/src/main/java/com/zero/bwtableback/statistics/entity/StatisticsType.java
+++ b/src/main/java/com/zero/bwtableback/statistics/entity/StatisticsType.java
@@ -1,9 +1,9 @@
 package com.zero.bwtableback.statistics.entity;
 
-public enum StatisticsType { //
-    DAILY,          // 일별 통계
-    WEEKLY,         // 주별 통계
-    MONTHLY,        // 월별 통계
-    TIME_SLOT,      // 인기 시간대 통계
-    POPULAR_DATE    // 인기 날짜 통계
+public enum StatisticsType {
+    DAILY,          // 일별 통계: 하루 단위로 예약 건수를 집계
+    WEEKLY,         // 주별 통계: 한 주(일요일~토요일) 단위로 예약 건수를 집계
+    MONTHLY,        // 월별 통계: 한 달 단위로 예약 건수를 집계
+    TIME_SLOT,      // 인기 시간대 통계: 시간대 단위로 예약 건수를 집계
+    POPULAR_DATE    // 인기 날짜 통계: 특정 기간 내 예약이 많았던 상위 일자 5개 집계
 }

--- a/src/main/java/com/zero/bwtableback/statistics/entity/StatisticsType.java
+++ b/src/main/java/com/zero/bwtableback/statistics/entity/StatisticsType.java
@@ -1,0 +1,9 @@
+package com.zero.bwtableback.statistics.entity;
+
+public enum StatisticsType { //
+    DAILY,          // 일별 통계
+    WEEKLY,         // 주별 통계
+    MONTHLY,        // 월별 통계
+    TIME_SLOT,      // 인기 시간대 통계
+    POPULAR_DATE    // 인기 날짜 통계
+}

--- a/src/main/java/com/zero/bwtableback/statistics/repository/StatisticsRepository.java
+++ b/src/main/java/com/zero/bwtableback/statistics/repository/StatisticsRepository.java
@@ -1,0 +1,10 @@
+package com.zero.bwtableback.statistics.repository;
+
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.entity.StatisticsType;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatisticsRepository extends JpaRepository<Statistics, Long> {
+    List<Statistics> findByRestaurantIdAndType(Long restaurantId, StatisticsType type);
+}

--- a/src/main/java/com/zero/bwtableback/statistics/scheduler/StatisticsScheduler.java
+++ b/src/main/java/com/zero/bwtableback/statistics/scheduler/StatisticsScheduler.java
@@ -1,0 +1,73 @@
+package com.zero.bwtableback.statistics.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StatisticsScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job dailyStatisticsJob;
+    private final Job weeklyStatisticsJob;
+    private final Job monthlyStatisticsJob;
+    private final Job popularTimeSlotsJob;
+    private final Job popularDatesJob;
+
+    @Scheduled(cron = "0 0 1 * * ?") // 매일 새벽 1시 실행
+    public void runDailyStatisticsJob() throws Exception {
+        try {
+            jobLauncher.run(dailyStatisticsJob, new JobParameters());
+            log.info("일별 예약 통계 저장을 성공적으로 완료했습니다.");
+        } catch (Exception e) {
+            log.error("일별 예약 통계 저장에 실패했습니다.", e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 2 ? * SUN") // 매주 일요일 새벽 2시 실행
+    public void runWeeklyStatisticsJob() throws Exception {
+        try {
+            jobLauncher.run(weeklyStatisticsJob, new JobParameters());
+            log.info("주별 예약 통계 저장을 성공적으로 완료했습니다.");
+        } catch (Exception e) {
+            log.error("주별 예약 통계 저장에 실패했습니다.", e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 3 1 * ?") // 매월 1일 새벽 3시 실행
+    public void runMonthlyStatisticsJob() {
+        try {
+            jobLauncher.run(monthlyStatisticsJob, new JobParameters());
+            log.info("월별 예약 통계 저장을 성공적으로 완료했습니다.");
+        } catch (Exception e) {
+            log.error("월별 예약 통계 저장에 실패했습니다.", e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 4 * * ?") // 매일 새벽 4시 실행
+    public void runPopularTimeSlotsJob() {
+        try {
+            jobLauncher.run(popularTimeSlotsJob, new JobParameters());
+            log.info("인기 예약 시간대 통계 저장을 성공적으로 완료했습니다.");
+        } catch (Exception e) {
+            log.error("인기 예약 시간대 통계 저장에 실패했습니다.", e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 5 * * ?") // 매일 새벽 5시 실행
+    public void runPopularDatesJob() {
+        try {
+            jobLauncher.run(popularDatesJob, new JobParameters());
+            log.info("인기 예약 일자 통계 저장을 성공적으로 완료했습니다.");
+        } catch (Exception e) {
+            log.error("인기 예약 일자 통계 저장에 실패했습니다.", e);
+        }
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/statistics/scheduler/StatisticsScheduler.java
+++ b/src/main/java/com/zero/bwtableback/statistics/scheduler/StatisticsScheduler.java
@@ -9,8 +9,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Slf4j
-@Component
 @RequiredArgsConstructor
+@Component
 public class StatisticsScheduler {
 
     private final JobLauncher jobLauncher;

--- a/src/main/java/com/zero/bwtableback/statistics/service/StatisticsService.java
+++ b/src/main/java/com/zero/bwtableback/statistics/service/StatisticsService.java
@@ -1,0 +1,61 @@
+package com.zero.bwtableback.statistics.service;
+
+import com.zero.bwtableback.statistics.dto.StatisticsDto;
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.entity.StatisticsType;
+import com.zero.bwtableback.statistics.repository.StatisticsRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class StatisticsService {
+
+    private final StatisticsRepository statisticsRepository;
+
+    // 일별 예약 건수 조회
+    public List<StatisticsDto> getDailyReservationsLast30Days(Long restaurantId) {
+        List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
+                restaurantId,
+                StatisticsType.DAILY);
+        return StatisticsDto.fromEntities(statistics);
+    }
+
+    // 주별 예약 건수 조회
+    public List<StatisticsDto> getWeeklyReservationsLast12Weeks(Long restaurantId) {
+        List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
+                restaurantId,
+                StatisticsType.WEEKLY
+        );
+        return StatisticsDto.fromEntities(statistics);
+    }
+
+    // 월별 예약 건수 조회
+    public List<StatisticsDto> getMonthlyReservationsLast6Months(Long restaurantId) {
+        List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
+                restaurantId,
+                StatisticsType.MONTHLY
+        );
+        return StatisticsDto.fromEntities(statistics);
+    }
+
+    // 인기 시간대 조회
+    public List<StatisticsDto> getPopularTimesLast30Days(Long restaurantId) {
+        List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
+                restaurantId,
+                StatisticsType.TIME_SLOT
+        );
+        return StatisticsDto.fromEntities(statistics);
+    }
+
+    // 인기 일자 조회
+    public List<StatisticsDto> getTop5PopularDatesLast30Days(Long restaurantId) {
+        List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
+                restaurantId,
+                StatisticsType.POPULAR_DATE
+        );
+        return StatisticsDto.fromEntities(statistics);
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/statistics/util/DateRangeCalculator.java
+++ b/src/main/java/com/zero/bwtableback/statistics/util/DateRangeCalculator.java
@@ -1,0 +1,35 @@
+package com.zero.bwtableback.statistics.util;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+
+public class DateRangeCalculator {
+
+    public static LocalDate getEndDateForMonthRange(LocalDate today) {
+        if (isLastDayOfMonth(today)) {
+            return today;
+        }
+        return getLastDayOfPreviousMonth(today);
+    }
+
+    public static LocalDate getStartDateForMonthRange(LocalDate date) {
+        return date.minusMonths(6).with(TemporalAdjusters.firstDayOfMonth());
+    }
+
+    public static LocalDate getStartOfWeekRange(LocalDate endDate, int weeksAgo) {
+        return endDate.minusWeeks(weeksAgo).with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.SUNDAY));
+    }
+
+    public static LocalDate getEndOfWeekRange(LocalDate currentDate) {
+        return currentDate.with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.SATURDAY));
+    }
+
+    private static LocalDate getLastDayOfPreviousMonth(LocalDate date) {
+        return date.minusMonths(1).with(TemporalAdjusters.lastDayOfMonth());
+    }
+
+    private static boolean isLastDayOfMonth(LocalDate date) {
+        return date.equals(date.with(TemporalAdjusters.lastDayOfMonth()));
+    }
+
+}

--- a/src/main/java/com/zero/bwtableback/statistics/util/PeriodKeyGenerator.java
+++ b/src/main/java/com/zero/bwtableback/statistics/util/PeriodKeyGenerator.java
@@ -1,0 +1,25 @@
+package com.zero.bwtableback.statistics.util;
+
+import java.time.LocalDate;
+import java.time.temporal.WeekFields;
+
+public class PeriodKeyGenerator {
+
+    public static String generateDailyKey(LocalDate date) {
+        return date.toString(); // "YYYY-MM-DD"
+    }
+
+    public static String generateWeeklyKey(LocalDate date) {
+        return date.getYear() + "-W" + getWeekOfYear(date); // "YYYY-Wxx"
+    }
+
+    public static String generateMonthlyKey(LocalDate date) {
+        return date.getYear() + "-" + String.format("%02d", date.getMonthValue()); // "YYYY-MM"
+    }
+
+    private static int getWeekOfYear(LocalDate date) {
+        return date.get(WeekFields.ISO.weekOfYear());
+    }
+
+}
+

--- a/src/test/java/com/zero/bwtableback/statistics/StatisticsServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/statistics/StatisticsServiceTest.java
@@ -1,0 +1,143 @@
+package com.zero.bwtableback.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.zero.bwtableback.statistics.dto.StatisticsDto;
+import com.zero.bwtableback.statistics.entity.Statistics;
+import com.zero.bwtableback.statistics.entity.StatisticsType;
+import com.zero.bwtableback.statistics.repository.StatisticsRepository;
+import com.zero.bwtableback.statistics.service.StatisticsService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StatisticsServiceTest {
+
+    @Mock
+    private StatisticsRepository statisticsRepository;
+
+    @InjectMocks
+    private StatisticsService statisticsService;
+
+    @DisplayName("일별 예약 건수 - 최근 30일 데이터 반환")
+    @Test
+    void shouldReturnDailyReservationsLast30Days() {
+        // given
+        Long restaurantId = 1L;
+        List<Statistics> mockStatistics = List.of(
+                new Statistics(1L, null, StatisticsType.DAILY, "2024-11-01", 10),
+                new Statistics(2L, null, StatisticsType.DAILY, "2024-11-02", 8)
+        );
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.DAILY))
+                .willReturn(mockStatistics);
+
+        // when
+        List<StatisticsDto> result = statisticsService.getDailyReservationsLast30Days(restaurantId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).periodKey()).isEqualTo("2024-11-01");
+        assertThat(result.get(0).reservationCount()).isEqualTo(10);
+        assertThat(result.get(1).periodKey()).isEqualTo("2024-11-02");
+        assertThat(result.get(1).reservationCount()).isEqualTo(8);
+    }
+
+    @DisplayName("주별 예약 건수 - 최근 12주 데이터 반환")
+    @Test
+    void shouldReturnWeeklyReservationsLast12Weeks() {
+        // given
+        Long restaurantId = 1L;
+        List<Statistics> mockStatistics = List.of(
+                new Statistics(1L, null, StatisticsType.WEEKLY, "2024-W44", 50),
+                new Statistics(2L, null, StatisticsType.WEEKLY, "2024-W45", 65)
+        );
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.WEEKLY))
+                .willReturn(mockStatistics);
+
+        // when
+        List<StatisticsDto> result = statisticsService.getWeeklyReservationsLast12Weeks(restaurantId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).periodKey()).isEqualTo("2024-W44");
+        assertThat(result.get(0).reservationCount()).isEqualTo(50);
+        assertThat(result.get(1).periodKey()).isEqualTo("2024-W45");
+        assertThat(result.get(1).reservationCount()).isEqualTo(65);
+    }
+
+    @DisplayName("월별 예약 건수 - 최근 6개월 데이터 반환")
+    @Test
+    void shouldReturnMonthlyReservationsLast6Months() {
+        // given
+        Long restaurantId = 1L;
+        List<Statistics> mockStatistics = List.of(
+                new Statistics(1L, null, StatisticsType.MONTHLY, "2024-06", 300),
+                new Statistics(2L, null, StatisticsType.MONTHLY, "2024-07", 320)
+        );
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.MONTHLY))
+                .willReturn(mockStatistics);
+
+        // when
+        List<StatisticsDto> result = statisticsService.getMonthlyReservationsLast6Months(restaurantId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).periodKey()).isEqualTo("2024-06");
+        assertThat(result.get(0).reservationCount()).isEqualTo(300);
+        assertThat(result.get(1).periodKey()).isEqualTo("2024-07");
+        assertThat(result.get(1).reservationCount()).isEqualTo(320);
+    }
+
+    @DisplayName("인기 예약 시간대 - 최근 30일 데이터 반환")
+    @Test
+    void shouldReturnPopularTimesLast30Days() {
+        // given
+        Long restaurantId = 1L;
+        List<Statistics> mockStatistics = List.of(
+                new Statistics(1L, null, StatisticsType.TIME_SLOT, "18:00", 80),
+                new Statistics(2L, null, StatisticsType.TIME_SLOT, "19:00", 75)
+        );
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.TIME_SLOT))
+                .willReturn(mockStatistics);
+
+        // when
+        List<StatisticsDto> result = statisticsService.getPopularTimesLast30Days(restaurantId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).periodKey()).isEqualTo("18:00");
+        assertThat(result.get(0).reservationCount()).isEqualTo(80);
+        assertThat(result.get(1).periodKey()).isEqualTo("19:00");
+        assertThat(result.get(1).reservationCount()).isEqualTo(75);
+    }
+
+    @DisplayName("인기 예약 일자 - 최근 30일 TOP 5 데이터 반환")
+    @Test
+    void shouldReturnTop5PopularDatesLast30Days() {
+        // given
+        Long restaurantId = 1L;
+        List<Statistics> mockStatistics = List.of(
+                new Statistics(1L, null, StatisticsType.POPULAR_DATE, "2024-11-11", 25),
+                new Statistics(2L, null, StatisticsType.POPULAR_DATE, "2024-11-15", 20)
+        );
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.POPULAR_DATE))
+                .willReturn(mockStatistics);
+
+        // when
+        List<StatisticsDto> result = statisticsService.getTop5PopularDatesLast30Days(restaurantId);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).periodKey()).isEqualTo("2024-11-11");
+        assertThat(result.get(0).reservationCount()).isEqualTo(25);
+        assertThat(result.get(1).periodKey()).isEqualTo("2024-11-15");
+        assertThat(result.get(1).reservationCount()).isEqualTo(20);
+    }
+
+}


### PR DESCRIPTION
### 변경 사항
- [X] 신규 기능 추가
- [X] 테스트

### 작업 내역
통계 유형별로 필요한 데이터를 조회하고 반환하는 기능을 추가했습니다.

[통계 엔티티 생성]
- `type`필드를 추가해 통계 유형을 서비스 요구 기능과 동일하게 분류했습니다.
- `timeKey`필드를 활용해 집계한 예약 건수가 해당하는 시간을 나타냈습니다.

[통계 레포지토리 생성]
- 집계한 내역을 저장소에 저장합니다.
- 통계 유형 및 가게에 따라 조회 메서드를 추가했습니다.
- 예약 내역 저장소에서 기간별 예약 건수를 조회하는 커스텀 쿼리 메서드를 추가했습니다.

[배치 기능 추가]
- 쿼리 결과 리스트를 통계 엔티티로 변환해 저장하는 작업을 배치로 처리하고 스케쥴링을 나눠서 적용했습니다.

[유틸 클래스 추가]
- 통계 유형에 따라 조회에 필요한 날짜 범위를 동적으로 생성하는 유틸 클래스를 추가했습니다.
- 월 단위 통계는 해당 월의 1일부터 마지막 날까지를 포함하도록 날짜를 조정했습니다.
- 주 단위 통계는 일요일부터 토요일까지를 한 주로 계산하도록 날짜를 조정했습니다.
- `timeKey`는 주어진 날짜를 기반으로 통계 유형에 맞춰 생성됩니다. (예, 날짜: "2024-11-01", 주: "2024-W45", 월: "2024-11")

### 테스트
- [X] 테스트 추가
- [X] 모든 테스트가 통과

## 다음 진행사항
- 통계 데이터 처리 로직을 리팩토링하고 지난 데이터 삭제 로직을 추가할 예정입니다.

## 참고
closes #74 
