### PR TITLE
알림 및 통계 기능에 권한 검증 로직 추가

### DIFF
--- a/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
@@ -40,8 +40,8 @@ public class NotificationEmitterService {
     }
 
     // 동일한 알림을 고객과 가게 주인에게 모두 전송
-    public void sendNotificationToCustomerAndOwner(Long customerId, Long ownerId, Notification notification) {
-        sendNotificationToConnectedUser(customerId, notification);
+    public void sendNotificationToGuestAndOwner(Long guestId, Long ownerId, Notification notification) {
+        sendNotificationToConnectedUser(guestId, notification);
         sendNotificationToConnectedUser(ownerId, notification);
     }
 

--- a/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
@@ -48,23 +48,23 @@ public class NotificationEmitterService {
     // 회원의 활성화된 emitter에 알림 전송
     public void sendNotificationToConnectedUser(Long memberId, Notification notification) {
         List<String> emitterIds = emitterRepository.findAllEmitterIdsByMemberId(memberId);
-        String jsonMessage = createNotificationMessage(notification);
 
         emitterIds.forEach(emitterId -> {
             SseEmitter emitter = emitterRepository.findById(emitterId);
             if (emitter != null) {
-                sendMessageByEmitter(emitter, emitterId, jsonMessage);
+                sendMessageByEmitter(emitter, emitterId, notification);
             }
         });
     }
 
     // 해당 emitter로 메시지 전송
-    private void sendMessageByEmitter(SseEmitter emitter, String emitterId, String message) {
+    private void sendMessageByEmitter(SseEmitter emitter, String emitterId, Notification notification) {
         try {
+            String jsonMessage = createNotificationMessage(notification);
             emitter.send(SseEmitter.event()
                     .name("reservation-notification")
-                    .id(emitterId)
-                    .data(message));
+                    .id(String.valueOf(notification.getId()))
+                    .data(jsonMessage));
         } catch (Exception e) {
             log.error("알림 전송이 실패했습니다. {}: {}", emitterId, e.getMessage());
             emitter.completeWithError(e);

--- a/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/NotificationEmitterService.java
@@ -63,12 +63,12 @@ public class NotificationEmitterService {
         try {
             emitter.send(SseEmitter.event()
                     .name("reservation-notification")
-                    .id(emitterId) // 이벤트 ID를 emitterId로 설정
+                    .id(emitterId)
                     .data(message));
         } catch (Exception e) {
             log.error("알림 전송이 실패했습니다. {}: {}", emitterId, e.getMessage());
-            emitter.completeWithError(e); // 연결 종료
-            emitterRepository.removeEmitter(emitterId); // emitter 제거
+            emitter.completeWithError(e);
+            emitterRepository.removeEmitter(emitterId);
         }
     }
 
@@ -96,7 +96,7 @@ public class NotificationEmitterService {
     private String createNotificationMessage(Notification notification) {
         Map<String, Object> notificationData = new HashMap<>();
         notificationData.put("message", notification.getMessage());
-        notificationData.put("customerId", notification.getReservation().getMember().getId());
+        notificationData.put("guestId", notification.getReservation().getMember().getId());
         notificationData.put("ownerId", notification.getReservation().getRestaurant().getMember().getId());
         notificationData.put("reservationId", notification.getReservation().getId());
         notificationData.put("status", notification.getStatus());
@@ -107,4 +107,5 @@ public class NotificationEmitterService {
             throw new CustomException(ErrorCode.JSON_PARSING_FAILED);
         }
     }
+
 }

--- a/src/main/java/com/zero/bwtableback/reservation/service/NotificationScheduleService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/NotificationScheduleService.java
@@ -67,9 +67,9 @@ public class NotificationScheduleService {
 
     // 가게 주인과 고객에게 알림 전송
     public void sendNotification(Notification notification) {
-        Long customerId = notification.getReservation().getMember().getId();
+        Long guestId = notification.getReservation().getMember().getId();
         Long ownerId = notification.getReservation().getRestaurant().getMember().getId();
-        notificationEmitterService.sendNotificationToCustomerAndOwner(customerId, ownerId, notification);
+        notificationEmitterService.sendNotificationToGuestAndOwner(guestId, ownerId, notification);
         markAsSent(notification);
     }
 

--- a/src/main/java/com/zero/bwtableback/reservation/service/NotificationSearchService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/NotificationSearchService.java
@@ -1,7 +1,8 @@
 package com.zero.bwtableback.reservation.service;
 
-import static com.zero.bwtableback.reservation.entity.NotificationStatus.SENT;
-
+import com.zero.bwtableback.common.exception.CustomException;
+import com.zero.bwtableback.common.exception.ErrorCode;
+import com.zero.bwtableback.reservation.dto.NotificationResDto;
 import com.zero.bwtableback.reservation.entity.Notification;
 import com.zero.bwtableback.reservation.entity.NotificationStatus;
 import com.zero.bwtableback.reservation.entity.NotificationType;
@@ -33,7 +34,8 @@ public class NotificationSearchService {
     }
 
     // 클라이언트에서 직접 메시지를 작성을 원하는 경우 활용할 수 있는 데이터 반환
-    public Map<String, Object> createNotificationData(Reservation reservation, NotificationType type) {
+    public Map<String, Object> createNotificationData(Long memberId, Reservation reservation, NotificationType type) {
+        validateReservationAccess(memberId, reservation);
         Map<String, Object> notificationData = new HashMap<>();
         notificationData.put("reservationDate", reservation.getReservationDate().toString());
         notificationData.put("reservationTime", reservation.getReservationTime().toString());
@@ -41,6 +43,13 @@ public class NotificationSearchService {
         notificationData.put("customerName", reservation.getMember().getName());
         notificationData.put("type", type);
         return notificationData;
+    }
+
+    private void validateReservationAccess(Long memberId, Reservation reservation) {
+        if (!reservation.getMember().getId().equals(memberId) &&
+                !reservation.getRestaurant().getMember().getId().equals(memberId)) {
+            throw new CustomException(ErrorCode.UNAUTHORIZED_ACCESS);
+        }
     }
 
 }

--- a/src/main/java/com/zero/bwtableback/reservation/service/NotificationSearchService.java
+++ b/src/main/java/com/zero/bwtableback/reservation/service/NotificationSearchService.java
@@ -3,7 +3,6 @@ package com.zero.bwtableback.reservation.service;
 import com.zero.bwtableback.common.exception.CustomException;
 import com.zero.bwtableback.common.exception.ErrorCode;
 import com.zero.bwtableback.reservation.dto.NotificationResDto;
-import com.zero.bwtableback.reservation.entity.Notification;
 import com.zero.bwtableback.reservation.entity.NotificationStatus;
 import com.zero.bwtableback.reservation.entity.NotificationType;
 import com.zero.bwtableback.reservation.entity.Reservation;
@@ -22,15 +21,17 @@ public class NotificationSearchService {
     private final NotificationRepository notificationRepository;
 
     // 고객 회원에게 전송된 알림 목록 조회
-    public Page<Notification> getNotificationsSentToCustomer(Long customerId, Pageable pageable) {
+    public Page<NotificationResDto> getNotificationsSentToGuest(Long guestId, Pageable pageable) {
         return notificationRepository.findByReservation_Member_IdAndStatusOrderBySentTimeDesc(
-                customerId, SENT, pageable);
+                guestId, NotificationStatus.SENT, pageable)
+                .map(NotificationResDto::fromEntity);
     }
 
     // 가게 주인 회원에게 전송된 알림 목록 조회
-    public Page<Notification> getNotificationsSentToOwner(Long ownerId, Pageable pageable) {
+    public Page<NotificationResDto> getNotificationsSentToOwner(Long ownerId, Pageable pageable) {
         return notificationRepository.findByReservation_Restaurant_Member_IdAndStatusOrderBySentTimeDesc(
-                ownerId, NotificationStatus.SENT, pageable);
+                ownerId, NotificationStatus.SENT, pageable)
+                .map(NotificationResDto::fromEntity);
     }
 
     // 클라이언트에서 직접 메시지를 작성을 원하는 경우 활용할 수 있는 데이터 반환
@@ -40,7 +41,7 @@ public class NotificationSearchService {
         notificationData.put("reservationDate", reservation.getReservationDate().toString());
         notificationData.put("reservationTime", reservation.getReservationTime().toString());
         notificationData.put("restaurantName", reservation.getRestaurant().getName());
-        notificationData.put("customerName", reservation.getMember().getName());
+        notificationData.put("guestName", reservation.getMember().getName());
         notificationData.put("type", type);
         return notificationData;
     }

--- a/src/main/java/com/zero/bwtableback/reservation/util/NotificationMessageGenerator.java
+++ b/src/main/java/com/zero/bwtableback/reservation/util/NotificationMessageGenerator.java
@@ -10,20 +10,20 @@ import java.time.LocalTime;
 public class NotificationMessageGenerator {
 
     public static String generateMessage(Reservation reservation, NotificationType type) {
-        String customerName = reservation.getMember().getName();
+        String guestName = reservation.getMember().getName();
         String restaurantName = reservation.getRestaurant().getName();
         LocalDate reservationDate = reservation.getReservationDate();
         LocalTime reservationTime = reservation.getReservationTime();
 
         return switch (type) {
             case CONFIRMATION -> String.format("예약이 확정되었습니다! %s에 %s님이 %s %s에 방문 예정입니다.",
-                    restaurantName, customerName, reservationDate, reservationTime);
+                    restaurantName, guestName, reservationDate, reservationTime);
             case CANCELLATION -> String.format("예약 취소 안내드립니다. %s에서 %s님의 %s %s 예약이 취소되었습니다.",
-                    restaurantName, customerName, reservationDate, reservationTime);
+                    restaurantName, guestName, reservationDate, reservationTime);
             case REMINDER_24H -> String.format("예약 리마인더: %s에서 %s님의 %s %s 예약이 24시간 남았습니다.",
-                    restaurantName, customerName, reservationDate, reservationTime);
+                    restaurantName, guestName, reservationDate, reservationTime);
             case DAY_OF_VISIT -> String.format("오늘 예약이 있습니다! %s에서 %s님이 %s에 방문 예정입니다.",
-                    restaurantName, customerName, reservationTime);
+                    restaurantName, guestName, reservationTime);
             default -> throw new CustomException(ErrorCode.NOTIFICATION_NOT_FOUND);
         };
     }

--- a/src/main/java/com/zero/bwtableback/statistics/controller/StatisticsController.java
+++ b/src/main/java/com/zero/bwtableback/statistics/controller/StatisticsController.java
@@ -1,9 +1,12 @@
 package com.zero.bwtableback.statistics.controller;
 
+import com.zero.bwtableback.security.MemberDetails;
 import com.zero.bwtableback.statistics.dto.StatisticsDto;
 import com.zero.bwtableback.statistics.service.StatisticsService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,34 +14,40 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
 @RestController
+@PreAuthorize("hasRole('OWNER')")
 @RequestMapping("/api/statistics")
 public class StatisticsController {
 
     private final StatisticsService statisticsService;
 
     @GetMapping("/{restaurantId}/daily")
-    public List<StatisticsDto> getDailyReservationsLast30Days(@PathVariable Long restaurantId) {
-        return statisticsService.getDailyReservationsLast30Days(restaurantId);
+    public List<StatisticsDto> getDailyReservationsLast30Days(@PathVariable Long restaurantId,
+                                                              @AuthenticationPrincipal MemberDetails memberDetails) {
+        return statisticsService.getDailyReservationsLast30Days(restaurantId, memberDetails.getMemberId());
     }
 
     @GetMapping("/{restaurantId}/weekly")
-    public List<StatisticsDto> getWeeklyReservationsLast12Weeks(@PathVariable Long restaurantId) {
-        return statisticsService.getWeeklyReservationsLast12Weeks(restaurantId);
+    public List<StatisticsDto> getWeeklyReservationsLast12Weeks(@PathVariable Long restaurantId,
+                                                                @AuthenticationPrincipal MemberDetails memberDetails) {
+        return statisticsService.getWeeklyReservationsLast12Weeks(restaurantId, memberDetails.getMemberId());
     }
 
     @GetMapping("/{restaurantId}/monthly")
-    public List<StatisticsDto> getMonthlyReservationsLast6Months(@PathVariable Long restaurantId) {
-        return statisticsService.getMonthlyReservationsLast6Months(restaurantId);
+    public List<StatisticsDto> getMonthlyReservationsLast6Months(@PathVariable Long restaurantId,
+                                                                 @AuthenticationPrincipal MemberDetails memberDetails) {
+        return statisticsService.getMonthlyReservationsLast6Months(restaurantId, memberDetails.getMemberId());
     }
 
     @GetMapping("/{restaurantId}/popular-times")
-    public List<StatisticsDto> getPopularTimesLast30Days(@PathVariable Long restaurantId) {
-        return statisticsService.getPopularTimesLast30Days(restaurantId);
+    public List<StatisticsDto> getPopularTimesLast30Days(@PathVariable Long restaurantId,
+                                                         @AuthenticationPrincipal MemberDetails memberDetails) {
+        return statisticsService.getPopularTimesLast30Days(restaurantId, memberDetails.getMemberId());
     }
 
     @GetMapping("/{restaurantId}/popular-dates")
-    public List<StatisticsDto> getTop5PopularDatesLast30Days(@PathVariable Long restaurantId) {
-        return statisticsService.getTop5PopularDatesLast30Days(restaurantId);
+    public List<StatisticsDto> getTop5PopularDatesLast30Days(@PathVariable Long restaurantId,
+                                                             @AuthenticationPrincipal MemberDetails memberDetails) {
+        return statisticsService.getTop5PopularDatesLast30Days(restaurantId, memberDetails.getMemberId());
     }
 
 }

--- a/src/main/java/com/zero/bwtableback/statistics/service/StatisticsService.java
+++ b/src/main/java/com/zero/bwtableback/statistics/service/StatisticsService.java
@@ -1,5 +1,8 @@
 package com.zero.bwtableback.statistics.service;
 
+import com.zero.bwtableback.common.exception.CustomException;
+import com.zero.bwtableback.common.exception.ErrorCode;
+import com.zero.bwtableback.restaurant.repository.RestaurantRepository;
 import com.zero.bwtableback.statistics.dto.StatisticsDto;
 import com.zero.bwtableback.statistics.entity.Statistics;
 import com.zero.bwtableback.statistics.entity.StatisticsType;
@@ -13,9 +16,11 @@ import org.springframework.stereotype.Service;
 public class StatisticsService {
 
     private final StatisticsRepository statisticsRepository;
+    private final RestaurantRepository restaurantRepository;
 
     // 일별 예약 건수 조회
-    public List<StatisticsDto> getDailyReservationsLast30Days(Long restaurantId) {
+    public List<StatisticsDto> getDailyReservationsLast30Days(Long restaurantId, Long memberId) {
+        isOwnerOfRestaurant(restaurantId, memberId);
         List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
                 restaurantId,
                 StatisticsType.DAILY);
@@ -23,7 +28,8 @@ public class StatisticsService {
     }
 
     // 주별 예약 건수 조회
-    public List<StatisticsDto> getWeeklyReservationsLast12Weeks(Long restaurantId) {
+    public List<StatisticsDto> getWeeklyReservationsLast12Weeks(Long restaurantId, Long memberId) {
+        isOwnerOfRestaurant(restaurantId, memberId);
         List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
                 restaurantId,
                 StatisticsType.WEEKLY
@@ -32,7 +38,8 @@ public class StatisticsService {
     }
 
     // 월별 예약 건수 조회
-    public List<StatisticsDto> getMonthlyReservationsLast6Months(Long restaurantId) {
+    public List<StatisticsDto> getMonthlyReservationsLast6Months(Long restaurantId, Long memberId) {
+        isOwnerOfRestaurant(restaurantId, memberId);
         List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
                 restaurantId,
                 StatisticsType.MONTHLY
@@ -41,7 +48,8 @@ public class StatisticsService {
     }
 
     // 인기 시간대 조회
-    public List<StatisticsDto> getPopularTimesLast30Days(Long restaurantId) {
+    public List<StatisticsDto> getPopularTimesLast30Days(Long restaurantId, Long memberId) {
+        isOwnerOfRestaurant(restaurantId, memberId);
         List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
                 restaurantId,
                 StatisticsType.TIME_SLOT
@@ -50,12 +58,19 @@ public class StatisticsService {
     }
 
     // 인기 일자 조회
-    public List<StatisticsDto> getTop5PopularDatesLast30Days(Long restaurantId) {
+    public List<StatisticsDto> getTop5PopularDatesLast30Days(Long restaurantId, Long memberId) {
+        isOwnerOfRestaurant(restaurantId, memberId);
         List<Statistics> statistics = statisticsRepository.findByRestaurantIdAndType(
                 restaurantId,
                 StatisticsType.POPULAR_DATE
         );
         return StatisticsDto.fromEntities(statistics);
+    }
+
+    private void isOwnerOfRestaurant(Long restaurantId, Long memberId) {
+        if (!restaurantId.equals(restaurantRepository.findRestaurantIdByMemberId(memberId))) {
+            throw new CustomException(ErrorCode.RESTAURANT_OWNERSHIP_MISMATCH);
+        }
     }
 
 }

--- a/src/test/java/com/zero/bwtableback/reservation/service/NotificationEmitterServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/reservation/service/NotificationEmitterServiceTest.java
@@ -116,13 +116,13 @@ public class NotificationEmitterServiceTest {
     private Notification createMockNotification(Long memberId, Long ownerId) {
         Notification notification = mock(Notification.class);
         Reservation reservation = mock(Reservation.class);
-        Member customer = mock(Member.class);
+        Member guest = mock(Member.class);
         Member owner = mock(Member.class);
         Restaurant restaurant = mock(Restaurant.class);
 
         given(notification.getReservation()).willReturn(reservation);
-        given(reservation.getMember()).willReturn(customer);
-        given(customer.getId()).willReturn(memberId);
+        given(reservation.getMember()).willReturn(guest);
+        given(guest.getId()).willReturn(memberId);
         given(reservation.getRestaurant()).willReturn(restaurant);
         given(restaurant.getMember()).willReturn(owner);
         given(owner.getId()).willReturn(ownerId);

--- a/src/test/java/com/zero/bwtableback/reservation/service/NotificationScheduleServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/reservation/service/NotificationScheduleServiceTest.java
@@ -53,17 +53,17 @@ class NotificationScheduleServiceTest {
     void scheduleImmediateNotification_CreatesAndSendsNotification() {
         // given
         Reservation reservation = mock(Reservation.class);
-        Member customerMember = mock(Member.class);
+        Member guestMember = mock(Member.class);
         Member ownerMember = mock(Member.class);
         Restaurant restaurant = mock(Restaurant.class);
         Notification notification = mock(Notification.class);
 
         String message = "알림 메시지 예시";
 
-        given(reservation.getMember()).willReturn(customerMember);
+        given(reservation.getMember()).willReturn(guestMember);
         given(reservation.getRestaurant()).willReturn(restaurant);
         given(restaurant.getMember()).willReturn(ownerMember);
-        given(customerMember.getId()).willReturn(1L);
+        given(guestMember.getId()).willReturn(1L);
         given(ownerMember.getId()).willReturn(2L);
         given(notification.getReservation()).willReturn(reservation);
 
@@ -78,7 +78,7 @@ class NotificationScheduleServiceTest {
 
             // then
             verify(notificationRepository).save(any(Notification.class));
-            verify(notificationEmitterService).sendNotificationToCustomerAndOwner(1L, 2L, notification);
+            verify(notificationEmitterService).sendNotificationToGuestAndOwner(1L, 2L, notification);
         }
     }
 
@@ -120,11 +120,11 @@ class NotificationScheduleServiceTest {
     void scheduleImmediateNotification_ThrowsExceptionIfAlreadySent() {
         // given
         Reservation reservation = mock(Reservation.class);
-        Member customerMember = mock(Member.class);
+        Member guestMember = mock(Member.class);
         Member ownerMember = mock(Member.class);
         Restaurant restaurant = mock(Restaurant.class);
 
-        given(reservation.getMember()).willReturn(customerMember);
+        given(reservation.getMember()).willReturn(guestMember);
         given(reservation.getRestaurant()).willReturn(restaurant);
         given(restaurant.getMember()).willReturn(ownerMember);
 

--- a/src/test/java/com/zero/bwtableback/reservation/service/NotificationSearchServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/reservation/service/NotificationSearchServiceTest.java
@@ -44,7 +44,7 @@ class NotificationSearchServiceTest {
 
     @DisplayName("고객에게 전송된 알림 목록을 조회한다")
     @Test
-    void givenGuestId_whenGetNotificationsSentToCustomer_thenReturnNotifications() {
+    void givenGuestId_whenGetNotificationsSentToGuest_thenReturnNotifications() {
         // given
         Long guestId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
@@ -69,7 +69,7 @@ class NotificationSearchServiceTest {
 
         Page<Notification> notifications = new PageImpl<>(Collections.singletonList(notification), pageable, 1);
         when(notificationRepository.findByReservation_Member_IdAndStatusOrderBySentTimeDesc(
-                customerId, NotificationStatus.SENT, pageable))
+                guestId, NotificationStatus.SENT, pageable))
                 .thenReturn(notifications);
 
         // when
@@ -137,7 +137,7 @@ class NotificationSearchServiceTest {
         NotificationType type = NotificationType.REMINDER_24H;
 
         when(restaurant.getName()).thenReturn("Test Restaurant");
-        when(member.getName()).thenReturn("Test Customer");
+        when(member.getName()).thenReturn("Test Guest");
         when(member.getId()).thenReturn(memberId);
 
         // when
@@ -147,7 +147,7 @@ class NotificationSearchServiceTest {
         assertThat(notificationData).containsEntry("reservationDate", "2024-11-12");
         assertThat(notificationData).containsEntry("reservationTime", "18:00");
         assertThat(notificationData).containsEntry("restaurantName", "Test Restaurant");
-        assertThat(notificationData).containsEntry("customerName", "Test Customer");
+        assertThat(notificationData).containsEntry("guestName", "Test Guest");
         assertThat(notificationData).containsEntry("type", type);
     }
 

--- a/src/test/java/com/zero/bwtableback/reservation/service/NotificationSearchServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/reservation/service/NotificationSearchServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import com.zero.bwtableback.member.entity.Member;
+import com.zero.bwtableback.reservation.dto.NotificationResDto;
 import com.zero.bwtableback.reservation.entity.Notification;
 import com.zero.bwtableback.reservation.entity.NotificationStatus;
 import com.zero.bwtableback.reservation.entity.NotificationType;
@@ -43,9 +44,9 @@ class NotificationSearchServiceTest {
 
     @DisplayName("고객에게 전송된 알림 목록을 조회한다")
     @Test
-    void givenCustomerId_whenGetNotificationsSentToCustomer_thenReturnNotifications() {
+    void givenGuestId_whenGetNotificationsSentToCustomer_thenReturnNotifications() {
         // given
-        Long customerId = 1L;
+        Long guestId = 1L;
         Pageable pageable = PageRequest.of(0, 10);
 
         Reservation reservation = Reservation.builder()
@@ -72,12 +73,12 @@ class NotificationSearchServiceTest {
                 .thenReturn(notifications);
 
         // when
-        Page<Notification> result = notificationSearchService.getNotificationsSentToCustomer(customerId, pageable);
+        Page<NotificationResDto> result = notificationSearchService.getNotificationsSentToGuest(guestId, pageable);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getMessage()).isEqualTo("예약이 확정되었습니다.");
+        assertThat(result.getContent().get(0).message()).isEqualTo("예약이 확정되었습니다.");
     }
 
     @DisplayName("가게 주인에게 전송된 알림 목록을 조회한다")
@@ -111,19 +112,22 @@ class NotificationSearchServiceTest {
                 .thenReturn(notifications);
 
         // when
-        Page<Notification> result = notificationSearchService.getNotificationsSentToOwner(ownerId, pageable);
+        Page<NotificationResDto> result = notificationSearchService.getNotificationsSentToOwner(ownerId, pageable);
 
         // then
         assertThat(result).isNotNull();
         assertThat(result.getContent()).hasSize(1);
-        assertThat(result.getContent().get(0).getMessage()).isEqualTo("예약이 확정되었습니다.");
+        assertThat(result.getContent().get(0).message()).isEqualTo("예약이 확정되었습니다.");
     }
 
     @DisplayName("알림 내역 관련 데이터를 반환한다")
     @Test
-    void givenReservationAndNotificationType_whenCreateNotificationData_thenReturnNotificationData() {
+    void givenMemberIdReservationAndNotificationType_whenCreateNotificationData_thenReturnNotificationData() {
         // given
+        Long memberId = 1L;
+
         Reservation reservation = Reservation.builder()
+                .id(1L)
                 .reservationDate(LocalDate.of(2024, 11, 12))
                 .reservationTime(LocalTime.of(18, 0))
                 .restaurant(restaurant)
@@ -134,9 +138,10 @@ class NotificationSearchServiceTest {
 
         when(restaurant.getName()).thenReturn("Test Restaurant");
         when(member.getName()).thenReturn("Test Customer");
+        when(member.getId()).thenReturn(memberId);
 
         // when
-        Map<String, Object> notificationData = notificationSearchService.createNotificationData(reservation, type);
+        Map<String, Object> notificationData = notificationSearchService.createNotificationData(memberId, reservation, type);
 
         // then
         assertThat(notificationData).containsEntry("reservationDate", "2024-11-12");

--- a/src/test/java/com/zero/bwtableback/statistics/StatisticsServiceTest.java
+++ b/src/test/java/com/zero/bwtableback/statistics/StatisticsServiceTest.java
@@ -3,6 +3,7 @@ package com.zero.bwtableback.statistics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import com.zero.bwtableback.restaurant.repository.RestaurantRepository;
 import com.zero.bwtableback.statistics.dto.StatisticsDto;
 import com.zero.bwtableback.statistics.entity.Statistics;
 import com.zero.bwtableback.statistics.entity.StatisticsType;
@@ -22,6 +23,9 @@ class StatisticsServiceTest {
     @Mock
     private StatisticsRepository statisticsRepository;
 
+    @Mock
+    private RestaurantRepository restaurantRepository;
+
     @InjectMocks
     private StatisticsService statisticsService;
 
@@ -30,15 +34,16 @@ class StatisticsServiceTest {
     void shouldReturnDailyReservationsLast30Days() {
         // given
         Long restaurantId = 1L;
+        Long memberId = 1L;
         List<Statistics> mockStatistics = List.of(
                 new Statistics(1L, null, StatisticsType.DAILY, "2024-11-01", 10),
                 new Statistics(2L, null, StatisticsType.DAILY, "2024-11-02", 8)
         );
-        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.DAILY))
-                .willReturn(mockStatistics);
+        given(restaurantRepository.findRestaurantIdByMemberId(memberId)).willReturn(restaurantId);
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.DAILY)).willReturn(mockStatistics);
 
         // when
-        List<StatisticsDto> result = statisticsService.getDailyReservationsLast30Days(restaurantId);
+        List<StatisticsDto> result = statisticsService.getDailyReservationsLast30Days(restaurantId, memberId);
 
         // then
         assertThat(result).hasSize(2);
@@ -53,15 +58,16 @@ class StatisticsServiceTest {
     void shouldReturnWeeklyReservationsLast12Weeks() {
         // given
         Long restaurantId = 1L;
+        Long memberId = 1L;
         List<Statistics> mockStatistics = List.of(
                 new Statistics(1L, null, StatisticsType.WEEKLY, "2024-W44", 50),
                 new Statistics(2L, null, StatisticsType.WEEKLY, "2024-W45", 65)
         );
-        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.WEEKLY))
-                .willReturn(mockStatistics);
+        given(restaurantRepository.findRestaurantIdByMemberId(memberId)).willReturn(restaurantId);
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.WEEKLY)).willReturn(mockStatistics);
 
         // when
-        List<StatisticsDto> result = statisticsService.getWeeklyReservationsLast12Weeks(restaurantId);
+        List<StatisticsDto> result = statisticsService.getWeeklyReservationsLast12Weeks(restaurantId, memberId);
 
         // then
         assertThat(result).hasSize(2);
@@ -76,15 +82,16 @@ class StatisticsServiceTest {
     void shouldReturnMonthlyReservationsLast6Months() {
         // given
         Long restaurantId = 1L;
+        Long memberId = 1L;
         List<Statistics> mockStatistics = List.of(
                 new Statistics(1L, null, StatisticsType.MONTHLY, "2024-06", 300),
                 new Statistics(2L, null, StatisticsType.MONTHLY, "2024-07", 320)
         );
-        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.MONTHLY))
-                .willReturn(mockStatistics);
+        given(restaurantRepository.findRestaurantIdByMemberId(memberId)).willReturn(restaurantId);
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.MONTHLY)).willReturn(mockStatistics);
 
         // when
-        List<StatisticsDto> result = statisticsService.getMonthlyReservationsLast6Months(restaurantId);
+        List<StatisticsDto> result = statisticsService.getMonthlyReservationsLast6Months(restaurantId, memberId);
 
         // then
         assertThat(result).hasSize(2);
@@ -99,15 +106,16 @@ class StatisticsServiceTest {
     void shouldReturnPopularTimesLast30Days() {
         // given
         Long restaurantId = 1L;
+        Long memberId = 1L;
         List<Statistics> mockStatistics = List.of(
                 new Statistics(1L, null, StatisticsType.TIME_SLOT, "18:00", 80),
                 new Statistics(2L, null, StatisticsType.TIME_SLOT, "19:00", 75)
         );
-        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.TIME_SLOT))
-                .willReturn(mockStatistics);
+        given(restaurantRepository.findRestaurantIdByMemberId(memberId)).willReturn(restaurantId);
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.TIME_SLOT)).willReturn(mockStatistics);
 
         // when
-        List<StatisticsDto> result = statisticsService.getPopularTimesLast30Days(restaurantId);
+        List<StatisticsDto> result = statisticsService.getPopularTimesLast30Days(restaurantId, memberId);
 
         // then
         assertThat(result).hasSize(2);
@@ -122,15 +130,16 @@ class StatisticsServiceTest {
     void shouldReturnTop5PopularDatesLast30Days() {
         // given
         Long restaurantId = 1L;
+        Long memberId = 1L;
         List<Statistics> mockStatistics = List.of(
                 new Statistics(1L, null, StatisticsType.POPULAR_DATE, "2024-11-11", 25),
                 new Statistics(2L, null, StatisticsType.POPULAR_DATE, "2024-11-15", 20)
         );
-        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.POPULAR_DATE))
-                .willReturn(mockStatistics);
+        given(restaurantRepository.findRestaurantIdByMemberId(memberId)).willReturn(restaurantId);
+        given(statisticsRepository.findByRestaurantIdAndType(restaurantId, StatisticsType.POPULAR_DATE)).willReturn(mockStatistics);
 
         // when
-        List<StatisticsDto> result = statisticsService.getTop5PopularDatesLast30Days(restaurantId);
+        List<StatisticsDto> result = statisticsService.getTop5PopularDatesLast30Days(restaurantId, memberId);
 
         // then
         assertThat(result).hasSize(2);


### PR DESCRIPTION
### 변경 사항
- [X] 리팩토링

### 작업 내역
[엔드포인트 접근 권한 검증 추가]
- 각 컨트롤러에 맞는 사용자 접근 권한 검증을 추가했습니다.
- 알림은 각 사용자에 맞는 접근 권한을 설정하고, 통계는 가게 주인만 접근할 수 있도록 설정했습니다.

[인증된 사용자 정보를 활용한 검증 추가]
- 인증된 사용자 정보를 활용해서 예약 및 알림 조회에 대한 권한을 확인하는 서비스 로직을 추가했습니다.
- 알림은 데이터 반환 부분에 사용자 권한을 검증한 후 관련 데이터를 반환합니다. 
- 통계는 조회를 시도할 레스토랑에 대해 사용자 권한을 검증한 후 통계 데이터를 반환합니다.

[그 외 리팩토링]
- DTO로 맵핑하는 로직을 컨트롤러에서 서비스로 이동해서 책임 분리를 명확히 했습니다.
- 권한명과 일관되도록 손님 역할의 사용자에 대한 코드에서 `customer`로 표기된 부분을 `guest`로 수정했습니다.
- 알림 전달 로직에서 응답 값에 알림 id를 정확히 반환하도록 수정했습니다.


closes #101 